### PR TITLE
Modernize macOS Keychain API usage and fix QString conversion

### DIFF
--- a/backy_x/CMakeLists.txt
+++ b/backy_x/CMakeLists.txt
@@ -160,6 +160,10 @@ target_link_libraries(backy_full_gui PRIVATE
 )
 target_include_directories(backy_full_gui PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
+if(APPLE)
+    target_link_libraries(backy_full_gui PRIVATE Security)
+endif()
+
 # For Windows, to make it a GUI application without a console window
 if(WIN32)
     set_target_properties(backy_full_gui PROPERTIES WIN32_EXECUTABLE ON)
@@ -200,6 +204,9 @@ target_link_libraries(test_sftp_target PRIVATE
     # Let's assume SftpTarget_lib correctly pulls in what it needs from CredentialManager.
     # If linking fails for Qt types, add Qt6::Core here.
 )
+if(APPLE)
+    target_link_libraries(test_sftp_target PRIVATE Security)
+endif()
 # Add test to CTest
 add_test(NAME SftpTargetTests COMMAND test_sftp_target)
 

--- a/backy_x/CMakeLists.txt
+++ b/backy_x/CMakeLists.txt
@@ -77,6 +77,29 @@ add_library(LocalTarget_lib STATIC
 target_link_libraries(LocalTarget_lib PUBLIC backy_x_core) # LocalTarget might use IStorageTarget from core
 target_include_directories(LocalTarget_lib PUBLIC include) # So users of LocalTarget_lib find its headers and IStorageTarget
 
+# SftpTarget library
+add_library(SftpTarget_lib STATIC
+    src/targets/SftpTarget.cpp
+)
+target_link_libraries(SftpTarget_lib PUBLIC backy_x_core) # SftpTarget will use IStorageTarget from core
+target_include_directories(SftpTarget_lib PUBLIC include)
+
+# Link SftpTarget_lib with CURL and LibSSH2
+# CURL::libcurl and LibSSH2::libssh2 are modern CMake targets if find_package works well.
+# The existing CMakeLists.txt already calls find_package for CURL and LibSSH2.
+if(CURL_FOUND)
+    target_link_libraries(SftpTarget_lib PRIVATE CURL::libcurl)
+else()
+    message(WARNING "CURL not found. SftpTarget_lib will not have CURL functionality.")
+endif()
+
+if(LibSSH2_FOUND)
+    target_link_libraries(SftpTarget_lib PRIVATE LibSSH2::libssh2)
+else()
+    message(WARNING "LibSSH2 not found. SftpTarget_lib may have limited SFTP functionality if CURL relies on it and it's missing.")
+endif()
+
+
 # CredentialManager library
 set(CREDMAN_SOURCES src/util/CredentialManager.cpp) # Common base .cpp
 
@@ -115,14 +138,9 @@ endif()
 add_executable(backy_x_cli src/cli/main_cli.cpp)
 target_link_libraries(backy_x_cli PRIVATE LocalTarget_lib)
 # Add other necessary libraries like std::filesystem if needed explicitly on some compilers/platforms
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    # For GCC and Clang, std::filesystem might require linking -lstdc++fs or similar if not C++17 default
-    # However, with C++17 set, it should generally link automatically.
-    # If link errors occur, specific linker flags might be needed here.
-    # For M0, let's assume it links fine with CMAKE_CXX_STANDARD 17.
-elseif(MSVC)
-    # MSVC usually links std::filesystem automatically with /std:c++17
-endif()
+# For M0, let's assume it links fine with CMAKE_CXX_STANDARD 17.
+# Note: SftpTarget_lib is not directly added to backy_x_cli or backy_full_gui yet.
+# This will be done when it's ready to be used.
 
 # GUI Application
 add_executable(backy_full_gui
@@ -163,6 +181,22 @@ target_link_libraries(test_scheduler PRIVATE
 )
 # Add test to CTest
 add_test(NAME SchedulerTests COMMAND test_scheduler)
+
+# SftpTarget Tests
+add_executable(test_sftp_target tests/test_sftp_target.cpp)
+target_link_libraries(test_sftp_target PRIVATE
+    SftpTarget_lib  # The library we are testing
+    gtest_main      # For GoogleTest
+    # CURL::libcurl and LibSSH2::libssh2 are linked by SftpTarget_lib
+    # Qt6::Core might be needed if SftpTarget or CredentialManager uses Qt types directly in headers
+    # SftpTarget uses CredentialManager, which uses Qt6::Core. SftpTarget_lib links backy_x_core, which links Qt6::Core.
+    # CredentialManager_lib is also linked to SftpTarget (implicitly via SftpTarget's own .cpp including CredentialManager.h & create function)
+    # or should be explicitly if SftpTarget_lib doesn't build CredentialManager itself.
+    # Let's assume SftpTarget_lib correctly pulls in what it needs from CredentialManager.
+    # If linking fails for Qt types, add Qt6::Core here.
+)
+# Add test to CTest
+add_test(NAME SftpTargetTests COMMAND test_sftp_target)
 
 
 # --- Installation (Placeholder for M0) ---

--- a/backy_x/CMakeLists.txt
+++ b/backy_x/CMakeLists.txt
@@ -81,7 +81,10 @@ target_include_directories(LocalTarget_lib PUBLIC include) # So users of LocalTa
 add_library(SftpTarget_lib STATIC
     src/targets/SftpTarget.cpp
 )
-target_link_libraries(SftpTarget_lib PUBLIC backy_x_core) # SftpTarget will use IStorageTarget from core
+target_link_libraries(SftpTarget_lib 
+    PUBLIC backy_x_core       # For IStorageTarget
+    PRIVATE CredentialManager_lib # For createPlatformCredentialManager in SftpTarget.cpp
+)
 target_include_directories(SftpTarget_lib PUBLIC include)
 
 # Link SftpTarget_lib with CURL and LibSSH2
@@ -152,6 +155,8 @@ target_link_libraries(backy_full_gui PRIVATE
     Qt6::Concurrent 
     backy_x_core    
     LocalTarget_lib 
+    SftpTarget_lib      
+    CredentialManager_lib 
 )
 target_include_directories(backy_full_gui PRIVATE ${CMAKE_SOURCE_DIR}/src)
 

--- a/backy_x/CMakeLists.txt
+++ b/backy_x/CMakeLists.txt
@@ -83,7 +83,7 @@ add_library(SftpTarget_lib STATIC
 )
 target_link_libraries(SftpTarget_lib 
     PUBLIC backy_x_core       # For IStorageTarget
-    PRIVATE CredentialManager_lib # For createPlatformCredentialManager in SftpTarget.cpp
+    PUBLIC CredentialManager_lib # Changed from PRIVATE to PUBLIC
 )
 target_include_directories(SftpTarget_lib PUBLIC include)
 

--- a/backy_x/README.md
+++ b/backy_x/README.md
@@ -12,8 +12,10 @@ BackyFull is a multi-platform backup software (macOS, Windows, Linux) designed f
     *   View basic logs of backup operations and application events.
 *   **Command Line Interface (CLI):**
     *   Perform one-shot backups of a single file or files in the root of a directory.
-*   **Persistence:** Backup schedules (source, destination, time) configured via the GUI are saved and reloaded when the application starts.
-*   **Local Storage Target:** Initial support for backing up to a local directory.
+*   **Persistence:** Backup schedules (source, destination/SFTP configuration, time) configured via the GUI are saved and reloaded when the application starts.
+*   **Multiple Backup Targets:**
+    *   **Local Storage Target:** Support for backing up to a local directory.
+    *   **SFTP Target:** Support for backing up to a remote server via SFTP, with secure credential storage.
 
 ## Build Instructions
 
@@ -30,6 +32,7 @@ CMake is required to build BackyFull.
     ```bash
     cmake -S . -B build
     ```
+    **Dependencies for SFTP:** To build with SFTP support, `libcurl` (with SSL support, e.g., `libcurl4-openssl-dev` on Debian/Ubuntu) and `libssh2` (e.g., `libssh2-1-dev` on Debian/Ubuntu) development packages must be installed. CMake will warn if these are not found, and SFTP features might be disabled or limited.
 
 2.  **Build the project:**
     After configuration, build the executables:
@@ -38,7 +41,40 @@ CMake is required to build BackyFull.
     ```
     This will compile the CLI, GUI, and test executables.
 
-## How to Run
+## Configuration and Usage
+
+BackyFull supports different backup targets and scheduling.
+
+### Backup Mode Selection
+In the GUI, you can choose your desired backup mode:
+*   **Local Backup:** Saves backups to a local directory.
+*   **SFTP Backup:** Saves backups to a remote server using SFTP.
+
+### Local Backup Setup
+*   **Source Directory:** Select the directory you want to back up.
+*   **Destination Directory (Local):** Choose a local folder where backups will be stored. The source directory's contents will be backed up into a subfolder named after the source directory within this destination.
+
+### SFTP Backup Setup
+When "SFTP Backup" mode is selected, the following fields need to be configured:
+*   **SFTP Host:** The hostname or IP address of the SFTP server (e.g., `sftp.example.com`).
+*   **SFTP Port:** The port number for the SFTP server. Defaults to `22`.
+*   **SFTP Username:** Your username for the SFTP server.
+*   **SFTP Password:** Your password for the SFTP server.
+*   **SFTP Remote Path:** The absolute path on the remote server where the backup (within a subfolder named after your source directory) will be stored (e.g., `/home/user/backups/` or `/backups/`).
+*   **Save password securely:**
+    *   If checked, the entered SFTP password will be stored securely in the system's credential manager (e.g., macOS Keychain, Windows Credential Manager, libsecret on Linux).
+    *   If unchecked, the password will be used for the current session only and for any immediate scheduled task setup, but will not be stored persistently by BackyFull's credential manager. If a previously stored password exists for the host/user combination, unchecking this box will cause it to be deleted from the system's credential manager upon saving settings or applying the schedule.
+    *   For subsequent sessions or scheduled backups (if saved), `SftpTarget` will attempt to retrieve the password from the credential manager if the password field is left empty.
+
+### Scheduling Backups
+*   **Daily Backup Time:** Set the time for the automated daily backup.
+*   **Apply Schedule:** Click this button to save the current configuration (source, destination/SFTP settings, time) and activate the schedule. Scheduled SFTP backups will use securely stored credentials if saved.
+
+### Running Backups
+*   **Run Backup Now:** Click this button to perform an immediate backup with the currently configured settings (source, and active destination/SFTP target).
+*   Scheduled backups will run automatically at the set time.
+
+## How to Run (Launching the Application)
 
 ### GUI Application
 After building, you can run the GUI application from the build directory:
@@ -66,6 +102,9 @@ ctest --output-on-failure
 This will run all registered tests, including:
 *   `LocalTargetTests`: Tests for the local storage target functionality.
 *   `SchedulerTests`: Tests for the backup scheduling logic and persistence.
+*   `SftpTargetTests`: Tests for the SFTP storage target.
+    *   Offline tests run by default.
+    *   Online tests require a live SFTP server and specific environment variables to be set: `SFTP_TEST_HOST`, `SFTP_TEST_PORT`, `SFTP_TEST_USER`, `SFTP_TEST_PASSWORD`, `SFTP_TEST_REMOTE_BASE_PATH`. If these are not set, the online tests will be skipped.
 
 ## Contributing
 (Placeholder for future contribution guidelines)

--- a/backy_x/include/core/Scheduler.h
+++ b/backy_x/include/core/Scheduler.h
@@ -24,23 +24,36 @@ public:
     ~Scheduler() override;
 
     // Configures the daily backup task
-    void setDailyBackupTask(const QString& sourcePath, const QString& destinationPath, const QTime& scheduledTime, bool enabled = true);
+    // Configures the daily backup task
+    void setDailyBackupTask(const QString& sourcePath, 
+                            const QString& destinationPathOrIdentifier, // For local, it's path. For SFTP, it might be a descriptive string or empty.
+                            const QTime& scheduledTime, 
+                            bool enabled, 
+                            bool isSftpMode, 
+                            const QString& sftpHost = QString(), 
+                            int sftpPort = 22, 
+                            const QString& sftpUsername = QString(), 
+                            const QString& sftpRemotePath = QString());
 
     // Loads task from QSettings
     void loadTask();
     
-    // Manually trigger the backup (for "Run Now" button)
-    // This will emit the triggerBackup signal immediately with current task's paths
-    // Q_INVOKABLE void triggerBackupNow(); // Q_INVOKABLE if called from QML, not strictly needed for C++ signals
-
     QString sourcePath() const;
-    QString destinationPath() const;
+    QString destinationPath() const; // For local mode, or descriptive identifier for SFTP
     QTime scheduledTime() const;
     bool isEnabled() const;
+    bool isSftpMode() const; // Getter for SFTP mode
+
+    // Getters for SFTP configuration
+    QString sftpHost() const;
+    int sftpPort() const;
+    QString sftpUsername() const;
+    QString sftpRemotePath() const;
 
 signals:
     // Emitted when a scheduled backup is due
-    void backupTaskTriggered(const QString& sourcePath, const QString& destinationPath);
+    // The slot connected to this in MainWindow will use Scheduler's getters to fetch full config
+    void backupTaskTriggered(const QString& sourcePath, const QString& destinationOrIdentifier);
     // Emitted when task details change, so UI can update
     void taskChanged(); 
 
@@ -51,19 +64,32 @@ private:
     void saveTask(); // Saves current task to QSettings
     void scheduleNextCheck(); // Helper to arm the timer for the next day or initial check
 
-    QString currentSourcePath_;
-    QString currentDestinationPath_;
-    QTime currentScheduledTime_;
-    bool taskEnabled_;
+    QString m_currentSourcePath;
+    QString m_currentDestinationPath; // For local, this is the path. For SFTP, this might be a placeholder or unused if SFTP details are separate.
+    QTime m_currentScheduledTime;
+    bool m_taskEnabled;
+    
+    // SFTP specific settings
+    bool m_isSftpMode;
+    QString m_sftpHost;
+    int m_sftpPort;
+    QString m_sftpUsername;
+    QString m_sftpRemotePath;
 
-    QTimer* dailyTimer_; // Timer to check if backup is due
-    QSettings* settings_; // For persisting task details
+    QTimer* m_dailyTimer; // Timer to check if backup is due
+    QSettings* m_settings; // For persisting task details
 
+    // QSettings keys
     const QString SETTINGS_GROUP = "Scheduler";
     const QString KEY_SOURCE_PATH = "sourcePath";
-    const QString KEY_DEST_PATH = "destinationPath";
+    const QString KEY_DEST_PATH = "destinationPath"; // Or "destinationIdentifier"
     const QString KEY_SCHEDULED_TIME = "scheduledTime";
     const QString KEY_TASK_ENABLED = "taskEnabled";
+    const QString KEY_IS_SFTP_MODE = "isSftpMode";
+    const QString KEY_SFTP_HOST = "sftpHost";
+    const QString KEY_SFTP_PORT = "sftpPort";
+    const QString KEY_SFTP_USERNAME = "sftpUsername";
+    const QString KEY_SFTP_REMOTE_PATH = "sftpRemotePath";
 };
 
 #endif // SCHEDULER_H

--- a/backy_x/include/targets/SftpTarget.h
+++ b/backy_x/include/targets/SftpTarget.h
@@ -9,8 +9,7 @@
 
 #include "util/CredentialManager.h" // For CredentialManager
 
-// Forward declaration for CURL handle
-struct CURL;
+#include <curl/curl.h> // For CURL handle type definition
 
 class SftpTarget : public IStorageTarget {
 public:

--- a/backy_x/include/targets/SftpTarget.h
+++ b/backy_x/include/targets/SftpTarget.h
@@ -1,0 +1,38 @@
+#ifndef SFTPTARGET_H
+#define SFTPTARGET_H
+
+#include "core/IStorageTarget.h"
+#include <string>
+#include <vector>
+#include <map>    // For configuration
+#include <memory> // For std::unique_ptr
+
+#include "util/CredentialManager.h" // For CredentialManager
+
+// Forward declaration for CURL handle
+struct CURL;
+
+class SftpTarget : public IStorageTarget {
+public:
+    SftpTarget(const std::map<std::string, std::string>& config);
+    ~SftpTarget() override;
+
+    // Inherited via IStorageTarget
+    bool beginSession() override;
+    bool sendFile(const std::string& relativePath, const FileMetadata& metadata) override;
+    bool deleteFile(const std::string& relativePath) override;
+    bool endSession() override;
+
+private:
+    std::string m_host;
+    std::string m_username;
+    std::string m_password; // Alternatively, path to a key file
+    std::string m_remoteBasePath;
+    int m_port;
+
+    CURL* m_curlHandle; // For libcurl operations
+    std::unique_ptr<CredentialManager> m_credentialManager;
+    // Add other necessary members, e.g., for libssh2 if used directly
+};
+
+#endif // SFTPTARGET_H

--- a/backy_x/include/util/CredentialManager.h
+++ b/backy_x/include/util/CredentialManager.h
@@ -4,6 +4,10 @@
 #include <QString> // For service, username, secret
 #include <optional>  // For retrieveSecret return type
 
+// Forward declaration of the factory function implemented in platform-specific files
+class CredentialManager; // Forward declare the class itself for the function signature
+CredentialManager* createPlatformCredentialManager();
+
 class CredentialManager {
 public:
     // Virtual destructor is important for base classes

--- a/backy_x/src/core/Scheduler.cpp
+++ b/backy_x/src/core/Scheduler.cpp
@@ -1,44 +1,65 @@
 #include "core/Scheduler.h"
-#include <QDebug> // For logging/debug output
-#include <QCoreApplication> // For QSettings organization/app name if not already set
-#include <QDateTime> // Required for scheduleNextCheck logic
+#include <QDebug>
+#include <QCoreApplication>
+#include <QDateTime>
 
 Scheduler::Scheduler(const QString& settingsFilePath, QObject *parent)
     : QObject(parent),
-      taskEnabled_(false),
-      dailyTimer_(new QTimer(this)),
-      settings_(nullptr)
+      m_taskEnabled(false), // Renamed variables
+      m_isSftpMode(false),  // Initialize new SFTP flag
+      m_sftpPort(22),       // Default SFTP port
+      m_dailyTimer(new QTimer(this)), // Renamed
+      m_settings(nullptr)      // Renamed
 {
     if (settingsFilePath.isEmpty()) {
-        // Default behavior: use standard app/org settings
         if (QCoreApplication::organizationName().isEmpty()) {
-            QCoreApplication::setOrganizationName("BackyFullOrgTestDefault"); // Default for safety
+            QCoreApplication::setOrganizationName("BackyFullOrgTestDefault");
         }
         if (QCoreApplication::applicationName().isEmpty()) {
-            QCoreApplication::setApplicationName("BackyFullTestDefault");    // Default for safety
+            QCoreApplication::setApplicationName("BackyFullTestDefault");
         }
-        settings_ = new QSettings(QSettings::IniFormat, QSettings::UserScope,
-                                  QCoreApplication::organizationName(),
-                                  QCoreApplication::applicationName(), this);
+        m_settings = new QSettings(QSettings::IniFormat, QSettings::UserScope,
+                                   QCoreApplication::organizationName(),
+                                   QCoreApplication::applicationName(), this);
     } else {
-        // Use provided settings file path (typically for testing)
-        settings_ = new QSettings(settingsFilePath, QSettings::IniFormat, this);
+        m_settings = new QSettings(settingsFilePath, QSettings::IniFormat, this);
     }
     
-    connect(dailyTimer_, &QTimer::timeout, this, &Scheduler::checkScheduledTime);
-    loadTask(); // Load task settings on startup using the initialized settings_
+    connect(m_dailyTimer, &QTimer::timeout, this, &Scheduler::checkScheduledTime);
+    loadTask(); 
 }
 
 Scheduler::~Scheduler() {
-    // dailyTimer_ is a child of Scheduler, QObject parent-child cleanup handles it.
-    // settings_ is also a child.
+    // m_dailyTimer and m_settings are children, Qt handles cleanup.
 }
 
-void Scheduler::setDailyBackupTask(const QString& sourcePath, const QString& destinationPath, const QTime& scheduledTime, bool enabled) {
-    currentSourcePath_ = sourcePath;
-    currentDestinationPath_ = destinationPath;
-    currentScheduledTime_ = scheduledTime;
-    taskEnabled_ = enabled;
+void Scheduler::setDailyBackupTask(const QString& sourcePath, 
+                                   const QString& destinationPathOrIdentifier, 
+                                   const QTime& scheduledTime, 
+                                   bool enabled, 
+                                   bool isSftpMode,
+                                   const QString& sftpHost,
+                                   int sftpPort,
+                                   const QString& sftpUsername,
+                                   const QString& sftpRemotePath) {
+    m_currentSourcePath = sourcePath;
+    m_currentDestinationPath = destinationPathOrIdentifier; // Store identifier or local path
+    m_currentScheduledTime = scheduledTime;
+    m_taskEnabled = enabled;
+    m_isSftpMode = isSftpMode;
+
+    if (m_isSftpMode) {
+        m_sftpHost = sftpHost;
+        m_sftpPort = sftpPort;
+        m_sftpUsername = sftpUsername;
+        m_sftpRemotePath = sftpRemotePath;
+    } else {
+        // Clear SFTP details if not in SFTP mode to avoid confusion
+        m_sftpHost.clear();
+        m_sftpPort = 22; // Reset to default
+        m_sftpUsername.clear();
+        m_sftpRemotePath.clear();
+    }
 
     saveTask();
     scheduleNextCheck();
@@ -46,108 +67,148 @@ void Scheduler::setDailyBackupTask(const QString& sourcePath, const QString& des
 }
 
 void Scheduler::loadTask() {
-    settings_->beginGroup(SETTINGS_GROUP);
-    currentSourcePath_ = settings_->value(KEY_SOURCE_PATH, "").toString();
-    currentDestinationPath_ = settings_->value(KEY_DEST_PATH, "").toString();
-    currentScheduledTime_ = settings_->value(KEY_SCHEDULED_TIME, QTime(23, 0)).toTime(); // Default to 11 PM
-    taskEnabled_ = settings_->value(KEY_TASK_ENABLED, false).toBool();
-    settings_->endGroup();
+    m_settings->beginGroup(SETTINGS_GROUP);
+    m_currentSourcePath = m_settings->value(KEY_SOURCE_PATH, "").toString();
+    m_currentDestinationPath = m_settings->value(KEY_DEST_PATH, "").toString();
+    m_currentScheduledTime = m_settings->value(KEY_SCHEDULED_TIME, QTime(23, 0)).toTime();
+    m_taskEnabled = m_settings->value(KEY_TASK_ENABLED, false).toBool();
+    m_isSftpMode = m_settings->value(KEY_IS_SFTP_MODE, false).toBool();
+
+    if (m_isSftpMode) {
+        m_sftpHost = m_settings->value(KEY_SFTP_HOST, "").toString();
+        m_sftpPort = m_settings->value(KEY_SFTP_PORT, 22).toInt();
+        m_sftpUsername = m_settings->value(KEY_SFTP_USERNAME, "").toString();
+        m_sftpRemotePath = m_settings->value(KEY_SFTP_REMOTE_PATH, "").toString();
+    }
+    m_settings->endGroup();
 
     qDebug() << "Scheduler: Loaded task -"
-             << "Source:" << currentSourcePath_
-             << "Dest:" << currentDestinationPath_
-             << "Time:" << currentScheduledTime_.toString("HH:mm")
-             << "Enabled:" << taskEnabled_;
+             << "Source:" << m_currentSourcePath
+             << "Dest/ID:" << m_currentDestinationPath
+             << "Time:" << m_currentScheduledTime.toString("HH:mm")
+             << "Enabled:" << m_taskEnabled
+             << "SFTP Mode:" << m_isSftpMode;
+    if (m_isSftpMode) {
+        qDebug() << "SFTP Details - Host:" << m_sftpHost << "Port:" << m_sftpPort << "User:" << m_sftpUsername << "Path:" << m_sftpRemotePath;
+    }
 
     scheduleNextCheck();
     emit taskChanged();
 }
 
 void Scheduler::saveTask() {
-    settings_->beginGroup(SETTINGS_GROUP);
-    settings_->setValue(KEY_SOURCE_PATH, currentSourcePath_);
-    settings_->setValue(KEY_DEST_PATH, currentDestinationPath_);
-    settings_->setValue(KEY_SCHEDULED_TIME, currentScheduledTime_);
-    settings_->setValue(KEY_TASK_ENABLED, taskEnabled_);
-    settings_->endGroup();
-    settings_->sync(); // Ensure data is written
+    m_settings->beginGroup(SETTINGS_GROUP);
+    m_settings->setValue(KEY_SOURCE_PATH, m_currentSourcePath);
+    m_settings->setValue(KEY_DEST_PATH, m_currentDestinationPath);
+    m_settings->setValue(KEY_SCHEDULED_TIME, m_currentScheduledTime);
+    m_settings->setValue(KEY_TASK_ENABLED, m_taskEnabled);
+    m_settings->setValue(KEY_IS_SFTP_MODE, m_isSftpMode);
+
+    if (m_isSftpMode) {
+        m_settings->setValue(KEY_SFTP_HOST, m_sftpHost);
+        m_settings->setValue(KEY_SFTP_PORT, m_sftpPort);
+        m_settings->setValue(KEY_SFTP_USERNAME, m_sftpUsername);
+        m_settings->setValue(KEY_SFTP_REMOTE_PATH, m_sftpRemotePath);
+    } else {
+        // Remove SFTP keys if not in SFTP mode to keep settings clean
+        m_settings->remove(KEY_SFTP_HOST);
+        m_settings->remove(KEY_SFTP_PORT);
+        m_settings->remove(KEY_SFTP_USERNAME);
+        m_settings->remove(KEY_SFTP_REMOTE_PATH);
+    }
+    m_settings->endGroup();
+    m_settings->sync(); 
 
     qDebug() << "Scheduler: Saved task -"
-             << "Source:" << currentSourcePath_
-             << "Dest:" << currentDestinationPath_
-             << "Time:" << currentScheduledTime_.toString("HH:mm")
-             << "Enabled:" << taskEnabled_;
+             << "Source:" << m_currentSourcePath
+             << "Dest/ID:" << m_currentDestinationPath
+             << "Time:" << m_currentScheduledTime.toString("HH:mm")
+             << "Enabled:" << m_taskEnabled
+             << "SFTP Mode:" << m_isSftpMode;
+     if (m_isSftpMode) {
+        qDebug() << "SFTP Details - Host:" << m_sftpHost << "Port:" << m_sftpPort << "User:" << m_sftpUsername << "Path:" << m_sftpRemotePath;
+    }
 }
 
 void Scheduler::scheduleNextCheck() {
-    dailyTimer_->stop();
-    if (!taskEnabled_ || !currentScheduledTime_.isValid() || currentSourcePath_.isEmpty() || currentDestinationPath_.isEmpty()) {
-        qDebug() << "Scheduler: Task disabled or invalid, not scheduling.";
+    m_dailyTimer->stop(); // Renamed variable
+    if (!m_taskEnabled || !m_currentScheduledTime.isValid() || m_currentSourcePath.isEmpty() || 
+        (m_isSftpMode ? (m_sftpHost.isEmpty() || m_sftpUsername.isEmpty() || m_sftpRemotePath.isEmpty()) : m_currentDestinationPath.isEmpty())) {
+        qDebug() << "Scheduler: Task disabled or not fully configured for the current mode, not scheduling.";
         return;
     }
 
     QDateTime currentDateTime = QDateTime::currentDateTime();
-    QDateTime scheduledDateTime(currentDateTime.date(), currentScheduledTime_);
+    QDateTime scheduledDateTime(currentDateTime.date(), m_currentScheduledTime); // Renamed variable
 
     if (scheduledDateTime < currentDateTime) {
-        // If scheduled time for today has already passed, schedule for tomorrow
         scheduledDateTime = scheduledDateTime.addDays(1);
     }
 
     qint64 msecsUntilScheduled = currentDateTime.msecsTo(scheduledDateTime);
-    if (msecsUntilScheduled < 0) { // Should not happen if logic above is correct
+    if (msecsUntilScheduled < 0) { 
         msecsUntilScheduled = 0; 
     }
     
-    // For testing, one might use a shorter interval. For production, this is fine.
-    // The timer will fire once at the scheduled time.
-    // Then checkScheduledTime will re-arm it for the next day.
-    dailyTimer_->setSingleShot(true); // Ensures it fires once, then we reschedule
-    dailyTimer_->start(msecsUntilScheduled);
+    m_dailyTimer->setSingleShot(true); // Renamed variable
+    m_dailyTimer->start(msecsUntilScheduled); // Renamed variable
 
     qDebug() << "Scheduler: Next check scheduled for:" << scheduledDateTime.toString("yyyy-MM-dd HH:mm:ss")
              << "in" << msecsUntilScheduled / 1000.0 << "seconds.";
 }
 
 void Scheduler::checkScheduledTime() {
-    if (!taskEnabled_ || !currentScheduledTime_.isValid() || currentSourcePath_.isEmpty() || currentDestinationPath_.isEmpty()) {
-        qDebug() << "Scheduler: Check time called, but task is not active or fully configured.";
-        scheduleNextCheck(); // Reschedule even if not active, in case it becomes active later
+    if (!m_taskEnabled || !m_currentScheduledTime.isValid() || m_currentSourcePath.isEmpty() ||
+        (m_isSftpMode ? (m_sftpHost.isEmpty() || m_sftpUsername.isEmpty() || m_sftpRemotePath.isEmpty()) : m_currentDestinationPath.isEmpty())) {
+        qDebug() << "Scheduler: Check time called, but task is not active or fully configured for the current mode.";
+        scheduleNextCheck(); 
         return;
     }
 
     QTime currentTime = QTime::currentTime();
-    // Check if current time is "close enough" to scheduled time.
-    // QTimer might not be perfectly exact to the millisecond.
-    // A common approach is to check if current time is >= scheduled time and < scheduled time + a small delta (e.g., 1 minute)
-    // Or, since this timer is a single-shot specifically set for the scheduled time,
-    // we can assume if it fires, it's time.
-
     qDebug() << "Scheduler: Timer fired! Current time:" << currentTime.toString("HH:mm:ss")
-             << "Scheduled:" << currentScheduledTime_.toString("HH:mm");
+             << "Scheduled:" << m_currentScheduledTime.toString("HH:mm"); // Renamed variable
 
-    // Emit signal to trigger the backup
-    emit backupTaskTriggered(currentSourcePath_, currentDestinationPath_);
+    emit backupTaskTriggered(m_currentSourcePath, m_currentDestinationPath); // Renamed variables
     
-    // Reschedule for the next day
     scheduleNextCheck();
 }
 
 // --- Getter methods ---
 QString Scheduler::sourcePath() const {
-    return currentSourcePath_;
+    return m_currentSourcePath; // Renamed variable
 }
 
 QString Scheduler::destinationPath() const {
-    return currentDestinationPath_;
+    return m_currentDestinationPath; // Renamed variable (this is dest path for local, or identifier for SFTP)
 }
 
 QTime Scheduler::scheduledTime() const {
-    return currentScheduledTime_;
+    return m_currentScheduledTime; // Renamed variable
 }
 
 bool Scheduler::isEnabled() const {
-    return taskEnabled_;
+    return m_taskEnabled; // Renamed variable
+}
+
+bool Scheduler::isSftpMode() const {
+    return m_isSftpMode;
+}
+
+QString Scheduler::sftpHost() const {
+    return m_sftpHost;
+}
+
+int Scheduler::sftpPort() const {
+    return m_sftpPort;
+}
+
+QString Scheduler::sftpUsername() const {
+    return m_sftpUsername;
+}
+
+QString Scheduler::sftpRemotePath() const {
+    return m_sftpRemotePath;
 }
 
 // Example of how triggerBackupNow could be implemented if needed:

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -1,22 +1,27 @@
 #include "gui/MainWindow.h"
 #include "core/Scheduler.h"
-#include "targets/LocalTarget.h" // For M1, directly using LocalTarget
+#include "targets/LocalTarget.h"
+#include "targets/SftpTarget.h"     // Added
+#include "util/CredentialManager.h" // Added
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QGridLayout>
+#include <QFormLayout> // Added for sftpSettingsGroupBox_
 #include <QWidget>
 #include <QLabel>
 #include <QFileDialog>
-#include <QMessageBox> // For simple error/info messages
+#include <QMessageBox>
 #include <QTime>
-#include <QDir> // For path operations
-#include <QDebug> // For console debug output
-#include <QStandardPaths> // For default dialog paths
-#include <QSettings> // For window settings
-#include <QCoreApplication> // For QSettings org/app name
-#include <filesystem> // For recursive directory iteration and path manipulation
-#include <functional> // For std::function (if using a lambda helper)
+#include <QDir>
+#include <QDebug>
+#include <QStandardPaths>
+#include <QSettings>
+#include <QCoreApplication>
+#include <QCloseEvent> // Added
+#include <filesystem>
+#include <functional>
+#include <map> // Added for SftpTarget config
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent),
@@ -28,45 +33,59 @@ MainWindow::MainWindow(QWidget *parent)
       applyScheduleButton_(nullptr),
       runBackupButton_(nullptr),
       logDisplay_(nullptr),
-      scheduler_(nullptr), // Initialized properly in the body
-      localTarget_(nullptr), // Initialized later or when dest path is known
-      fileDialog_(nullptr) // Initialized in setupUI
+      scheduler_(nullptr), 
+      localTarget_(nullptr),
+      sftpTarget_(nullptr),             // Initialized
+      m_credentialManager(nullptr),   // Initialized
+      m_localDestinationGroupBox(nullptr), // Initialized
+      fileDialog_(nullptr),
+      backupModeComboBox_(nullptr),
+      sftpSettingsGroupBox_(nullptr),
+      sftpHostLineEdit_(nullptr),
+      sftpPortLineEdit_(nullptr),
+      sftpUsernameLineEdit_(nullptr),
+      sftpPasswordLineEdit_(nullptr),
+      sftpRemotePathLineEdit_(nullptr),
+      sftpSavePasswordCheckBox_(nullptr)
 {
-    // It's good practice to set OrganizationName and ApplicationName for QSettings
-    // This should ideally be done once in main() of the GUI app.
     if (QCoreApplication::organizationName().isEmpty()) {
         QCoreApplication::setOrganizationName("BackyFullOrg");
     }
     if (QCoreApplication::applicationName().isEmpty()) {
         QCoreApplication::setApplicationName("BackyFull");
     }
+    
+    m_credentialManager = std::unique_ptr<CredentialManager>(createPlatformCredentialManager());
+    scheduler_ = new Scheduler(QString(), this); 
 
-    scheduler_ = new Scheduler(QString(), this); // Scheduler is a child of MainWindow
-
-    setupUI();
-    loadSettings(); // Load window geometry and other UI settings
+    setupUI();      // Create UI elements first
+    loadSettings(); // Then load settings which might affect UI state (like combo box index)
 
     // Connect scheduler signals
-    connect(scheduler_, &Scheduler::backupTaskTriggered, this, &MainWindow::performBackup);
+    connect(scheduler_, &Scheduler::backupTaskTriggered, this, &MainWindow::handleScheduledBackup);
     connect(scheduler_, &Scheduler::taskChanged, this, &MainWindow::onTaskChanged);
 
-    // Initialize UI from scheduler's loaded task
-    onTaskChanged(); 
+    // Set initial UI state based on loaded settings (especially combo box)
+    if (backupModeComboBox_) { // backupModeComboBox_ is setup in setupUI()
+        onBackupModeChanged(backupModeComboBox_->currentIndex());
+    }
+    onTaskChanged(); // Reflect scheduler's initial state (which also loads from its own settings)
 
     updateLog("BackyFull application started.");
-    updateLog("Please configure your backup source, destination, and schedule.");
+    updateLog("Please configure your backup source, destination/SFTP, and schedule.");
 }
 
 MainWindow::~MainWindow() {
-    saveSettings();
-    // scheduler_ is a child, Qt handles its deletion.
-    // localTarget_ might need explicit deletion if not parented.
-    // If localTarget_ is created in performBackup and not parented, it should be deleted there or here.
-    // Current implementation in performBackup re-creates it if destination changes,
-    // but the last instance would leak if not deleted.
+    // saveSettings(); // Done in closeEvent
     delete localTarget_; 
     localTarget_ = nullptr;
-    // fileDialog_ is parented to 'this', so Qt should handle it.
+    delete sftpTarget_; 
+    sftpTarget_ = nullptr;
+}
+
+void MainWindow::closeEvent(QCloseEvent *event) {
+    saveSettings();
+    QMainWindow::closeEvent(event);
 }
 
 void MainWindow::setupUI() {
@@ -75,51 +94,101 @@ void MainWindow::setupUI() {
     QWidget *centralWidget = new QWidget(this);
     setCentralWidget(centralWidget);
 
-    QGridLayout *layout = new QGridLayout(centralWidget);
+    // Main vertical layout for the central widget
+    QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
+    
+    // --- Backup Mode Selection ---
+    QHBoxLayout *modeLayout = new QHBoxLayout(); // Use QHBoxLayout for label and combobox
+    modeLayout->addWidget(new QLabel(tr("Backup Mode:")));
+    backupModeComboBox_ = new QComboBox();
+    backupModeComboBox_->addItem(tr("Local Backup"));
+    backupModeComboBox_->addItem(tr("SFTP Backup"));
+    modeLayout->addWidget(backupModeComboBox_);
+    modeLayout->addStretch(); // Add stretch to push combobox to the left
+    mainLayout->addLayout(modeLayout);
 
-    // Source Directory
-    layout->addWidget(new QLabel(tr("Source Directory:")), 0, 0);
+
+    // --- Common Settings (Source Directory) ---
+    QGroupBox *sourceGroupBox = new QGroupBox(tr("Source Configuration"));
+    QGridLayout *sourceLayout = new QGridLayout(sourceGroupBox);
+    sourceLayout->addWidget(new QLabel(tr("Source Directory:")), 0, 0);
     sourceDirEdit_ = new QLineEdit();
-    sourceDirEdit_->setReadOnly(true); 
-    layout->addWidget(sourceDirEdit_, 0, 1);
+    sourceDirEdit_->setReadOnly(true);
+    sourceLayout->addWidget(sourceDirEdit_, 0, 1);
     sourceDirButton_ = new QPushButton(tr("Browse..."));
     connect(sourceDirButton_, &QPushButton::clicked, this, &MainWindow::selectSourceDirectory);
-    layout->addWidget(sourceDirButton_, 0, 2);
+    sourceLayout->addWidget(sourceDirButton_, 0, 2);
+    mainLayout->addWidget(sourceGroupBox);
 
-    // Destination Directory
-    layout->addWidget(new QLabel(tr("Destination Directory (Local):")), 1, 0);
+    // --- Local Destination Settings ---
+    m_localDestinationGroupBox = new QGroupBox(tr("Local Destination Configuration")); // Assign to member
+    QGridLayout *localDestLayout = new QGridLayout(m_localDestinationGroupBox);
+    localDestLayout->addWidget(new QLabel(tr("Destination Directory (Local):")), 0, 0);
     destinationDirEdit_ = new QLineEdit();
-    destinationDirEdit_->setReadOnly(true); 
-    layout->addWidget(destinationDirEdit_, 1, 1);
+    destinationDirEdit_->setReadOnly(true);
+    localDestLayout->addWidget(destinationDirEdit_, 0, 1);
     destinationDirButton_ = new QPushButton(tr("Browse..."));
     connect(destinationDirButton_, &QPushButton::clicked, this, &MainWindow::selectDestinationDirectory);
-    layout->addWidget(destinationDirButton_, 1, 2);
+    localDestLayout->addWidget(destinationDirButton_, 0, 2);
+    mainLayout->addWidget(m_localDestinationGroupBox);
 
-    // Backup Time
-    layout->addWidget(new QLabel(tr("Daily Backup Time:")), 2, 0);
+
+    // --- SFTP Settings GroupBox ---
+    sftpSettingsGroupBox_ = new QGroupBox(tr("SFTP Configuration"));
+    QFormLayout *sftpFormLayout = new QFormLayout(sftpSettingsGroupBox_);
+
+    sftpHostLineEdit_ = new QLineEdit();
+    sftpFormLayout->addRow(new QLabel(tr("SFTP Host:")), sftpHostLineEdit_);
+
+    sftpPortLineEdit_ = new QLineEdit();
+    sftpPortLineEdit_->setText("22"); // Default port
+    sftpPortLineEdit_->setValidator(new QIntValidator(1, 65535, this)); // Basic port validation
+    sftpFormLayout->addRow(new QLabel(tr("SFTP Port:")), sftpPortLineEdit_);
+
+    sftpUsernameLineEdit_ = new QLineEdit();
+    sftpFormLayout->addRow(new QLabel(tr("SFTP Username:")), sftpUsernameLineEdit_);
+
+    sftpPasswordLineEdit_ = new QLineEdit();
+    sftpPasswordLineEdit_->setEchoMode(QLineEdit::Password);
+    sftpFormLayout->addRow(new QLabel(tr("SFTP Password:")), sftpPasswordLineEdit_);
+    
+    sftpSavePasswordCheckBox_ = new QCheckBox(tr("Save password securely"));
+    sftpFormLayout->addRow(sftpSavePasswordCheckBox_); // QFormLayout handles checkbox layout well
+
+    sftpRemotePathLineEdit_ = new QLineEdit();
+    sftpFormLayout->addRow(new QLabel(tr("SFTP Remote Path:")), sftpRemotePathLineEdit_);
+    
+    mainLayout->addWidget(sftpSettingsGroupBox_);
+    // sftpSettingsGroupBox_->setVisible(false); // Visibility handled by onBackupModeChanged
+    connect(backupModeComboBox_, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MainWindow::onBackupModeChanged);
+
+
+    // --- Scheduling and Controls ---
+    QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Controls"));
+    QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
+
+    scheduleLayout->addWidget(new QLabel(tr("Daily Backup Time:")), 0, 0);
     backupTimeEdit_ = new QTimeEdit();
     backupTimeEdit_->setDisplayFormat("HH:mm");
-    layout->addWidget(backupTimeEdit_, 2, 1);
+    scheduleLayout->addWidget(backupTimeEdit_, 0, 1, 1, 2); // Span 2 columns for time edit
 
-    // Apply Schedule Button
     applyScheduleButton_ = new QPushButton(tr("Apply Schedule"));
     connect(applyScheduleButton_, &QPushButton::clicked, this, &MainWindow::applySchedule);
-    layout->addWidget(applyScheduleButton_, 3, 0, 1, 3); 
+    scheduleLayout->addWidget(applyScheduleButton_, 1, 0, 1, 3);
 
-    // Run Backup Now Button
     runBackupButton_ = new QPushButton(tr("Run Backup Now"));
     connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
-    layout->addWidget(runBackupButton_, 4, 0, 1, 3); 
+    scheduleLayout->addWidget(runBackupButton_, 2, 0, 1, 3);
+    mainLayout->addWidget(scheduleGroupBox);
 
-    // Log Display
-    layout->addWidget(new QLabel(tr("Logs:")), 5, 0);
+    // --- Log Display ---
+    mainLayout->addWidget(new QLabel(tr("Logs:")));
     logDisplay_ = new QTextEdit();
     logDisplay_->setReadOnly(true);
-    layout->addWidget(logDisplay_, 6, 0, 1, 3); 
+    mainLayout->addWidget(logDisplay_);
+    mainLayout->setStretchFactor(logDisplay_, 1); // Make log display expand
 
-    layout->setRowStretch(6, 1); 
-
-    fileDialog_ = new QFileDialog(this);
+    fileDialog_ = new QFileDialog(this); // Keep this for browse dialogs
 }
 
 void MainWindow::selectSourceDirectory() {
@@ -148,79 +217,168 @@ void MainWindow::selectDestinationDirectory() {
 
 void MainWindow::applySchedule() {
     QString sourcePath = sourceDirEdit_->text();
-    QString destPath = destinationDirEdit_->text();
     QTime backupTime = backupTimeEdit_->time();
 
-    if (sourcePath.isEmpty() || destPath.isEmpty()) {
-        QMessageBox::warning(this, tr("Configuration Error"), tr("Source and destination paths cannot be empty."));
-        updateLog("Error: Failed to apply schedule. Source or destination empty.");
+    if (sourcePath.isEmpty()) {
+        QMessageBox::warning(this, tr("Configuration Error"), tr("Source path cannot be empty."));
+        updateLog("Error: Failed to apply schedule. Source path empty.");
         return;
     }
-    if (!backupTime.isValid()) {
+     if (!backupTime.isValid()) {
         QMessageBox::warning(this, tr("Configuration Error"), tr("The selected backup time is invalid."));
         updateLog("Error: Failed to apply schedule. Invalid time.");
         return;
     }
 
-    scheduler_->setDailyBackupTask(sourcePath, destPath, backupTime, true); 
-    updateLog(QString("Schedule applied: Backup at %1 for source '%2' to '%3'.").arg(backupTime.toString("HH:mm"), sourcePath, destPath));
+    QString effectiveDestPath; // Used for scheduler and logging
+    bool sftpMode = (backupModeComboBox_->currentIndex() == 1); // 0 for Local, 1 for SFTP
+
+    if (sftpMode) {
+        if (sftpHostLineEdit_->text().isEmpty() || sftpUsernameLineEdit_->text().isEmpty() || sftpRemotePathLineEdit_->text().isEmpty()) {
+             QMessageBox::warning(this, tr("Configuration Error"), tr("SFTP Host, Username, and Remote Path cannot be empty for SFTP mode."));
+             updateLog("Error: Failed to apply schedule for SFTP. Required fields missing.");
+             return;
+        }
+        // For SFTP, the "destination path" for the scheduler is more conceptual.
+        // It combines host and remote path for uniqueness if needed by scheduler logic.
+        effectiveDestPath = QString("sftp://%1%2").arg(sftpHostLineEdit_->text(), sftpRemotePathLineEdit_->text());
+        
+        // CredentialManager interaction during "Apply Schedule" mirrors saveSettings logic
+        if (m_credentialManager) {
+            QString serviceName = QString("sftp_%1_%2").arg(sftpHostLineEdit_->text()).arg(sftpPortLineEdit_->text().toInt());
+            QString qUsername = sftpUsernameLineEdit_->text();
+            QString qPassword = sftpPasswordLineEdit_->text();
+            if (sftpSavePasswordCheckBox_->isChecked()) {
+                if (!qPassword.isEmpty()) {
+                    updateLog("SFTP Schedule: Storing password via CredentialManager.");
+                    m_credentialManager->storeSecret(serviceName, qUsername, qPassword);
+                }
+            } else {
+                updateLog("SFTP Schedule: 'Save Password' not checked. Removing any stored password.");
+                m_credentialManager->deleteSecret(serviceName, qUsername);
+            }
+        }
+    } else { // Local Backup
+        effectiveDestPath = destinationDirEdit_->text();
+        if (effectiveDestPath.isEmpty()) {
+            QMessageBox::warning(this, tr("Configuration Error"), tr("Destination path cannot be empty for local backup."));
+            updateLog("Error: Failed to apply schedule for Local Backup. Destination path empty.");
+            return;
+        }
+    }
+
+    // Update scheduler; scheduler needs to know if it's an SFTP task for its persistence.
+    if (sftpMode) {
+        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPath, backupTime, true, 
+                                       sftpMode, 
+                                       sftpHostLineEdit_->text(), 
+                                       sftpPortLineEdit_->text().toInt(), 
+                                       sftpUsernameLineEdit_->text(), 
+                                       sftpRemotePathLineEdit_->text());
+    } else {
+        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPath, backupTime, true, 
+                                       sftpMode); // Pass default/empty SFTP params
+    }
+    updateLog(QString("Schedule applied: Backup at %1 for source '%2' to '%3' (SFTP Mode: %4).")
+                  .arg(backupTime.toString("HH:mm"), sourcePath, effectiveDestPath, sftpMode ? "Yes" : "No"));
     QMessageBox::information(this, tr("Schedule Updated"), tr("Backup schedule has been updated and saved."));
 }
 
 void MainWindow::runBackupNow() {
     QString sourcePath = sourceDirEdit_->text();
-    QString destPath = destinationDirEdit_->text();
+    if (sourcePath.isEmpty()) {
+        QMessageBox::warning(this, tr("Backup Error"), tr("Source path must be configured."));
+        updateLog("Error: Manual backup failed. Source path empty.");
+        return;
+    }
 
-    if (sourcePath.isEmpty() || destPath.isEmpty()) {
-        QMessageBox::warning(this, tr("Backup Error"), tr("Source and destination paths must be configured before running a backup."));
-        updateLog("Error: Manual backup failed. Source or destination empty.");
+    bool sftpMode = (backupModeComboBox_->currentIndex() == 1);
+    IStorageTarget* currentTarget = nullptr;
+
+    delete localTarget_; localTarget_ = nullptr; // Clear previous targets
+    delete sftpTarget_; sftpTarget_ = nullptr;
+
+    if (sftpMode) {
+        updateLog("SFTP Mode selected for manual backup.");
+        if (sftpHostLineEdit_->text().isEmpty() || sftpUsernameLineEdit_->text().isEmpty() || sftpRemotePathLineEdit_->text().isEmpty()) {
+             QMessageBox::warning(this, tr("Backup Error"), tr("SFTP Host, Username, and Remote Path must be configured."));
+             updateLog("Error: Manual SFTP backup failed. Required SFTP fields missing.");
+             return;
+        }
+
+        std::map<std::string, std::string> sftpConfig;
+        sftpConfig["host"] = sftpHostLineEdit_->text().toStdString();
+        sftpConfig["port"] = sftpPortLineEdit_->text().toStdString();
+        sftpConfig["username"] = sftpUsernameLineEdit_->text().toStdString();
+        sftpConfig["remoteBasePath"] = sftpRemotePathLineEdit_->text().toStdString();
+
+        QString qPasswordFromField = sftpPasswordLineEdit_->text();
+        if (!qPasswordFromField.isEmpty()) {
+            sftpConfig["password"] = qPasswordFromField.toStdString();
+            updateLog("SFTP: Using password from field for this session.");
+        }
+        // SftpTarget's constructor handles CredentialManager interaction based on whether "password" is in its config.
+        // If "password" is in config, SftpTarget's CredentialManager logic will store it if it's configured to do so (which it is).
+        // If "password" is NOT in config, SftpTarget's CredentialManager logic will try to retrieve it.
+        // The sftpSavePasswordCheckBox_ primarily influences what *MainWindow* saves via its own QSettings and CredentialManager calls,
+        // SftpTarget itself has its own internal logic for when it receives a password.
+
+        sftpTarget_ = new SftpTarget(sftpConfig); // SftpTarget handles its own credential manager logic internally now
+        currentTarget = sftpTarget_;
+        updateLog(QString("Manual SFTP backup started: From '%1' to host '%2'.").arg(sourcePath, QString::fromStdString(sftpConfig["host"])));
+
+    } else { // Local Backup
+        updateLog("Local Mode selected for manual backup.");
+        QString destPath = destinationDirEdit_->text();
+        if (destPath.isEmpty()) {
+            QMessageBox::warning(this, tr("Backup Error"), tr("Destination path must be configured for local backup."));
+            updateLog("Error: Manual backup failed. Local destination path empty.");
+            return;
+        }
+        
+        std::filesystem::path fsSourcePath(sourcePath.toStdString());
+        std::filesystem::path fsDestinationPathFromUI(destPath.toStdString());
+        std::filesystem::path backupRootForTarget = fsDestinationPathFromUI / fsSourcePath.filename();
+        
+        localTarget_ = new LocalTarget(backupRootForTarget.string());
+        currentTarget = localTarget_;
+        updateLog(QString("Manual Local backup started: From '%1' to '%2'.").arg(sourcePath, destPath));
+    }
+
+    if (!currentTarget) {
+        QMessageBox::critical(this, tr("Backup Error"), tr("Failed to initialize backup target."));
+        updateLog("Error: Manual backup failed. Target initialization failed.");
         return;
     }
     
-    updateLog(QString("Manual backup started: From '%1' to '%2'.").arg(sourcePath, destPath));
-    performBackup(sourcePath, destPath);
+    performBackupInternal(sourcePath, currentTarget);
 }
 
-void MainWindow::performBackup(const QString& sourcePath, const QString& destinationPath) {
-    updateLog(QString("Performing backup: Source: %1, Destination: %2").arg(sourcePath, destinationPath));
-
-    std::filesystem::path fsSourcePath(sourcePath.toStdString());
-    QString sourceFolderName = QString::fromStdString(fsSourcePath.filename().string());
-    if (sourceFolderName.isEmpty() || sourceFolderName == "." || sourceFolderName == "..") {
-        // This case should ideally be handled by input validation before calling performBackup,
-        // or use a default name like "root_backup" if sourcePath is "/"
-        updateLog(QString("Error: Could not determine a valid source folder name from '%1'.").arg(sourcePath));
-        QMessageBox::critical(this, tr("Backup Failed"), tr("Invalid source path. Cannot determine source folder name."));
+// Renamed from performBackup and takes IStorageTarget*
+void MainWindow::performBackupInternal(const QString& sourcePath, IStorageTarget* target) {
+    if (!target) {
+        updateLog("Error: performBackupInternal called with null target.");
+        QMessageBox::critical(this, tr("Backup Failed"), tr("Internal error: Backup target not specified."));
         return;
     }
+    updateLog(QString("Performing backup using active target: Source: %1").arg(sourcePath));
+
+    std::filesystem::path fsSourcePath(sourcePath.toStdString());
     if (!std::filesystem::is_directory(fsSourcePath)) {
          updateLog(QString("Error: Source path '%1' is not a directory.").arg(sourcePath));
          QMessageBox::critical(this, tr("Backup Failed"), tr("Source path is not a directory."));
          return;
     }
-
-
-    std::filesystem::path fsDestinationPathFromUI(destinationPath.toStdString());
-    std::filesystem::path backupRootForTarget = fsDestinationPathFromUI / fsSourcePath.filename();
-    std::string backupRootStdStr = backupRootForTarget.string();
-
-    if (localTarget_ && localTarget_->destinationPathStdStr() != backupRootStdStr) {
-        delete localTarget_;
-        localTarget_ = nullptr;
-    }
-    if (!localTarget_) {
-        localTarget_ = new LocalTarget(backupRootStdStr);
-    }
     
-    if (!localTarget_->beginSession()) {
-        updateLog(QString("Error: Could not begin backup session with LocalTarget at '%1'.").arg(QString::fromStdString(backupRootStdStr)));
+    if (!target->beginSession()) {
+        updateLog(QString("Error: Could not begin backup session with target. Check target logs."));
         QMessageBox::critical(this, tr("Backup Failed"), tr("Could not begin backup session. Check logs."));
         return;
     }
 
     if (!std::filesystem::exists(fsSourcePath)) {
         updateLog(QString("Error: Source directory '%1' does not exist.").arg(sourcePath));
-        localTarget_->endSession();
+        target->endSession(); // Attempt to clean up session
         QMessageBox::critical(this, tr("Backup Failed"), tr("Source directory not found."));
         return;
     }
@@ -235,20 +393,20 @@ void MainWindow::performBackup(const QString& sourcePath, const QString& destina
        try {
            for (const auto& entry : std::filesystem::directory_iterator(currentPathInSource)) {
                std::filesystem::path fullEntryPath = entry.path();
-               std::filesystem::path relativePath = std::filesystem::relative(fullEntryPath, fsSourcePath);
-               std::string relativePathStr = relativePath.generic_string(); // Use generic_string for platform-independent slashes
+               // IMPORTANT: SftpTarget expects remoteRelativePath as second argument to sendFile.
+               // LocalTarget also expects relativePath.
+               std::filesystem::path relativePathFs = std::filesystem::relative(fullEntryPath, fsSourcePath);
+               std::string relativePathStr = relativePathFs.generic_string(); 
 
                if (entry.is_directory()) {
                    updateLog(QString("Scanning subdirectory: %1").arg(QString::fromStdString(relativePathStr)));
-                   recursiveCopy(fullEntryPath); // Recurse
+                   recursiveCopy(fullEntryPath); 
                } else if (entry.is_regular_file()) {
                    files_processed_count++;
-                   // For M2, LocalTarget::sendFile expects the full path of the source file
-                   // and the relative path for constructing the destination.
-                   if (localTarget_->sendFile(fullEntryPath.string(), relativePathStr)) {
+                   if (target->sendFile(fullEntryPath.string(), relativePathStr)) { // Pass correct paths
                        updateLog(QString("Backed up: %1").arg(QString::fromStdString(relativePathStr)));
                    } else {
-                       updateLog(QString("Error backing up: %1").arg(QString::fromStdString(relativePathStr)));
+                       updateLog(QString("Error backing up: %1. Check target logs.").arg(QString::fromStdString(relativePathStr)));
                        all_ok = false; 
                    }
                }
@@ -259,11 +417,11 @@ void MainWindow::performBackup(const QString& sourcePath, const QString& destina
        }
     };
 
-    recursiveCopy(fsSourcePath); // Initial call to start the recursion
+    recursiveCopy(fsSourcePath); 
 
-    if (!localTarget_->endSession()) {
-        updateLog("Error: Could not properly end backup session with LocalTarget.");
-        all_ok = false; // Consider this a failure as well
+    if (!target->endSession()) {
+        updateLog("Error: Could not properly end backup session with target.");
+        all_ok = false; 
     }
 
     if (all_ok) {
@@ -289,30 +447,164 @@ void MainWindow::updateLog(const QString& message) {
 
 void MainWindow::onTaskChanged() {
     sourceDirEdit_->setText(scheduler_->sourcePath());
-    destinationDirEdit_->setText(scheduler_->destinationPath());
+    
+    // If scheduler was in SFTP mode, reflect this in UI.
+    // Scheduler's destinationPath might be the composite SFTP path or just the local path.
+    if (scheduler_->isSftpMode()) {
+        backupModeComboBox_->setCurrentText(tr("SFTP Backup")); // Or find by index
+        // SFTP fields (host, port, etc.) are loaded from their own QSettings group.
+        // destinationDirEdit_ (for local) should be empty or reflect last local path.
+        // The actual SFTP "destination" is composed from SFTP fields.
+    } else {
+        backupModeComboBox_->setCurrentText(tr("Local Backup"));
+        destinationDirEdit_->setText(scheduler_->destinationPath());
+    }
+    
     if (scheduler_->scheduledTime().isValid()) {
         backupTimeEdit_->setTime(scheduler_->scheduledTime());
     } else {
-        backupTimeEdit_->setTime(QTime(23,0)); 
+        // Provide a default time if scheduler's time is not valid (e.g., first run)
+        backupTimeEdit_->setTime(QTime(23, 0)); 
     }
-    updateLog("Task details updated in UI from Scheduler.");
+    // Ensure UI visibility matches the potentially updated mode from scheduler
+    onBackupModeChanged(backupModeComboBox_->currentIndex());
+    updateLog("Task details updated in UI from Scheduler state.");
+}
+
+void MainWindow::onBackupModeChanged(int index) {
+    bool sftpSelected = (backupModeComboBox_->itemText(index) == tr("SFTP Backup"));
+
+    if (m_localDestinationGroupBox) m_localDestinationGroupBox->setVisible(!sftpSelected);
+    if (sftpSettingsGroupBox_) sftpSettingsGroupBox_->setVisible(sftpSelected);
+    
+    updateLog(QString("Backup mode changed. SFTP Selected: %1").arg(sftpSelected ? "Yes" : "No"));
 }
 
 void MainWindow::loadSettings() {
     QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
     settings.beginGroup("MainWindow");
+
     const QByteArray geometry = settings.value("geometry", QByteArray()).toByteArray();
     if (!geometry.isEmpty()) {
         restoreGeometry(geometry);
     } else {
-        resize(600, 400); 
+        resize(800, 700); // Adjusted default size for more fields
     }
-    settings.endGroup();
+    
+    // Load backup mode. Scheduler also loads its own settings including source/dest/time/sftpMode.
+    // MainWindow settings primarily drive the UI elements not directly tied to a single scheduled task.
+    backupModeComboBox_->setCurrentIndex(settings.value("backupModeIndex", 0).toInt());
+    // sourceDirEdit_->setText(settings.value("lastSourcePath", "").toString()); // Or let Scheduler handle this
+    // destinationDirEdit_->setText(settings.value("lastLocalDestPath", "").toString()); // For local mode
+
+    settings.endGroup(); // MainWindow group
+
+    settings.beginGroup("SFTP");
+    sftpHostLineEdit_->setText(settings.value("host", "").toString());
+    sftpPortLineEdit_->setText(settings.value("port", "22").toString());
+    sftpUsernameLineEdit_->setText(settings.value("username", "").toString());
+    sftpRemotePathLineEdit_->setText(settings.value("remotePath", "").toString());
+    sftpSavePasswordCheckBox_->setChecked(settings.value("savePassword", false).toBool());
+    // Password itself is NOT loaded into sftpPasswordLineEdit_ from QSettings.
+    // SftpTarget's constructor will attempt to retrieve it from CredentialManager if not provided.
+    settings.endGroup(); // SFTP group
+    
+    updateLog("Settings loaded.");
+    // onBackupModeChanged() will be called after this from constructor to set initial visibility
 }
 
 void MainWindow::saveSettings() {
     QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
     settings.beginGroup("MainWindow");
     settings.setValue("geometry", saveGeometry());
-    settings.endGroup();
+    settings.setValue("backupModeIndex", backupModeComboBox_->currentIndex());
+    // settings.setValue("lastSourcePath", sourceDirEdit_->text()); // Scheduler handles task specific paths
+    // settings.setValue("lastLocalDestPath", destinationDirEdit_->text());
+    settings.endGroup(); // MainWindow group
+
+    settings.beginGroup("SFTP");
+    settings.setValue("host", sftpHostLineEdit_->text());
+    settings.setValue("port", sftpPortLineEdit_->text());
+    settings.setValue("username", sftpUsernameLineEdit_->text());
+    settings.setValue("remotePath", sftpRemotePathLineEdit_->text());
+    settings.setValue("savePassword", sftpSavePasswordCheckBox_->isChecked());
+    settings.endGroup(); // SFTP group
+
+    // Handle credential storage based on current SFTP UI state if SFTP mode is active
+    if (backupModeComboBox_->currentIndex() == 1) { // SFTP Mode
+        QString host = sftpHostLineEdit_->text();
+        QString port = sftpPortLineEdit_->text();
+        QString username = sftpUsernameLineEdit_->text();
+        QString passwordInField = sftpPasswordLineEdit_->text();
+
+        if (!host.isEmpty() && !port.isEmpty() && !username.isEmpty() && m_credentialManager) {
+            QString serviceName = QString("sftp_%1_%2").arg(host).arg(port.toInt());
+            if (sftpSavePasswordCheckBox_->isChecked()) {
+                // Only store/update if password field is not empty.
+                // If field is empty, user might want to rely on previously stored password.
+                if (!passwordInField.isEmpty()) {
+                    updateLog("Saving SFTP password to CredentialManager due to 'Save Password' checked and password field non-empty.");
+                    m_credentialManager->storeSecret(serviceName, username, passwordInField);
+                } else {
+                    updateLog("SFTP 'Save Password' is checked, but password field is empty. No change to stored password at this time.");
+                }
+            } else { 
+                // If "Save Password" is not checked, delete any existing password for this service/user.
+                updateLog("SFTP 'Save Password' is not checked. Removing any stored password from CredentialManager for this service.");
+                m_credentialManager->deleteSecret(serviceName, username);
+            }
+        }
+    }
+    updateLog("Settings saved.");
+}
+
+void MainWindow::handleScheduledBackup(const QString& sourcePath, const QString& destinationOrIdentifier) {
+    updateLog(QString("Scheduled backup triggered by Scheduler: Source '%1', Dest/ID '%2'")
+                  .arg(sourcePath, destinationOrIdentifier));
+
+    bool sftpMode = scheduler_->isSftpMode();
+    IStorageTarget* currentTarget = nullptr;
+
+    delete localTarget_; localTarget_ = nullptr;
+    delete sftpTarget_; sftpTarget_ = nullptr;
+
+    if (sftpMode) {
+        updateLog("Scheduled task is SFTP Mode.");
+        std::map<std::string, std::string> sftpConfig;
+        sftpConfig["host"] = scheduler_->sftpHost().toStdString();
+        sftpConfig["port"] = QString::number(scheduler_->sftpPort()).toStdString();
+        sftpConfig["username"] = scheduler_->sftpUsername().toStdString();
+        sftpConfig["remoteBasePath"] = scheduler_->sftpRemotePath().toStdString();
+        // Password is NOT included here; SftpTarget will use CredentialManager to retrieve it.
+        
+        sftpTarget_ = new SftpTarget(sftpConfig);
+        currentTarget = sftpTarget_;
+        updateLog(QString("Scheduled SFTP backup: From '%1' to host '%2'")
+                      .arg(sourcePath, scheduler_->sftpHost()));
+    } else {
+        updateLog("Scheduled task is Local Mode.");
+        // destinationOrIdentifier is the actual local destination path for local mode
+        if (destinationOrIdentifier.isEmpty()) {
+            updateLog("Error: Scheduled local backup triggered but destination path is empty in Scheduler.");
+            QMessageBox::critical(this, tr("Scheduled Backup Error"), tr("Destination path for scheduled local backup is missing."));
+            return;
+        }
+        
+        std::filesystem::path fsSourcePath(sourcePath.toStdString());
+        std::filesystem::path fsDestinationPathFromScheduler(destinationOrIdentifier.toStdString());
+        // For local target, destinationPath in scheduler is the root backup dir (e.g. /path/to/backup_folder/SourceDirName)
+        // So, LocalTarget constructor just needs this path.
+        localTarget_ = new LocalTarget(fsDestinationPathFromScheduler.string());
+        currentTarget = localTarget_;
+        updateLog(QString("Scheduled Local backup: From '%1' to '%2'")
+                      .arg(sourcePath, destinationOrIdentifier));
+    }
+
+    if (!currentTarget) {
+        QMessageBox::critical(this, tr("Scheduled Backup Error"), tr("Failed to initialize backup target for scheduled task."));
+        updateLog("Error: Scheduled backup failed. Target initialization failed.");
+        return;
+    }
+    
+    performBackupInternal(sourcePath, currentTarget);
 }

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -10,20 +10,36 @@
 #include <QTextEdit>
 #include <QTimeEdit>
 #include <QFileDialog>
+#include <QComboBox>     // For m_backupModeComboBox
+#include <QGroupBox>     // For m_sftpSettingsGroupBox
+#include <QCheckBox>     // For m_sftpSavePasswordCheckBox
+// QLineEdit is already included
+// QLabel will be included in .cpp or here if needed for direct use
 
 // Forward declaration for our Scheduler
-class Scheduler; 
+class Scheduler;
+#include "util/CredentialManager.h" // For CredentialManager
+#include <memory> // For std::unique_ptr
+
 // Forward declaration for IStorageTarget and LocalTarget
 class IStorageTarget;
 class LocalTarget;
+class SftpTarget; // Forward declare SftpTarget
+// Forward declarations for layout classes used in setupUI if not included,
+// but they are mostly implementation details of .cpp
+// class QFormLayout;
+// class QVBoxLayout;
 
 
-class MainWindow : public QMainWindow {
+class MainWindow : QMainWindow {
     Q_OBJECT
 
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow() override;
+
+protected:
+    void closeEvent(QCloseEvent *event) override; // To save settings on close
 
 private slots:
     void selectSourceDirectory();
@@ -32,6 +48,7 @@ private slots:
     void runBackupNow();
     void updateLog(const QString& message); // Slot to receive log messages
     void onTaskChanged(); // Slot to react to Scheduler's taskChanged signal
+    void onBackupModeChanged(int index); // Slot for backup mode change
 
 private:
     void setupUI(); // Helper to create and layout widgets
@@ -48,16 +65,36 @@ private:
     QPushButton *runBackupButton_;
     QTextEdit *logDisplay_;
 
+    // Backup Mode Selection
+    QComboBox *backupModeComboBox_;
+
+    // Local Backup Settings (existing widgets, maybe group them later)
+    // QLabel *destinationDirLabel_; // Will be changed based on mode
+
+    // SFTP Settings
+    QGroupBox *sftpSettingsGroupBox_;
+    QLineEdit *sftpHostLineEdit_;
+    QLineEdit *sftpPortLineEdit_;
+    QLineEdit *sftpUsernameLineEdit_;
+    QLineEdit *sftpPasswordLineEdit_;
+    QLineEdit *sftpRemotePathLineEdit_;
+    QCheckBox *sftpSavePasswordCheckBox_;
+
+
     // Core components
     Scheduler *scheduler_;
     // For M1, we'll directly use LocalTarget. Later, BackupEngine would manage IStorageTarget.
-    LocalTarget *localTarget_; // Will be initialized with destination path from UI
+    LocalTarget *localTarget_; 
+    SftpTarget *sftpTarget_; // Will be initialized based on mode
+
+    std::unique_ptr<CredentialManager> m_credentialManager;
 
     // Helper for file dialogs
     QFileDialog *fileDialog_;
 
     // Internal helper to perform the backup logic
-    void performBackup(const QString& sourcePath, const QString& destinationPath);
+    // This will use the currently active target (localTarget_ or sftpTarget_)
+    void performBackupInternal(const QString& sourcePath, IStorageTarget* target);
 };
 
 #endif // MAINWINDOW_H

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -31,7 +31,7 @@ class SftpTarget; // Forward declare SftpTarget
 // class QVBoxLayout;
 
 
-class MainWindow : QMainWindow {
+class MainWindow : public QMainWindow {
     Q_OBJECT
 
 public:
@@ -49,6 +49,7 @@ private slots:
     void updateLog(const QString& message); // Slot to receive log messages
     void onTaskChanged(); // Slot to react to Scheduler's taskChanged signal
     void onBackupModeChanged(int index); // Slot for backup mode change
+    void handleScheduledBackup(const QString& sourcePath, const QString& destinationOrIdentifier); // Slot for scheduled backups
 
 private:
     void setupUI(); // Helper to create and layout widgets
@@ -68,7 +69,8 @@ private:
     // Backup Mode Selection
     QComboBox *backupModeComboBox_;
 
-    // Local Backup Settings (existing widgets, maybe group them later)
+    // Local Backup Settings
+    QGroupBox *m_localDestinationGroupBox; // Declaration for the local destination group box
     // QLabel *destinationDirLabel_; // Will be changed based on mode
 
     // SFTP Settings

--- a/backy_x/src/targets/SftpTarget.cpp
+++ b/backy_x/src/targets/SftpTarget.cpp
@@ -1,0 +1,457 @@
+#include "targets/SftpTarget.h"
+#include <iostream> // For std::cerr/std::cout
+#include <fstream>  // For std::ifstream
+#include <filesystem> // For std::filesystem::path (C++17)
+#include <vector>   // For directory creation components
+
+#include <QString> // For service name and password with CredentialManager
+
+// For libcurl (SFTP operations)
+// Ensure libcurl is installed (e.g., sudo apt-get install libcurl4-openssl-dev)
+#include <curl/curl.h>
+
+// Note: libssh2 is often a dependency of libcurl when built with SFTP support.
+// Direct usage of libssh2 might not be needed if libcurl handles SFTP adequately.
+// If direct libssh2 usage is intended:
+// #include <libssh2.h>
+// #include <libssh2_sftp.h>
+// Ensure libssh2 is installed (e.g., sudo apt-get install libssh2-1-dev)
+
+// Static callback function for libcurl to read data for uploading
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream) {
+    std::ifstream *fileStream = static_cast<std::ifstream*>(stream);
+    fileStream->read(ptr, size * nmemb);
+    size_t bytesRead = fileStream->gcount();
+    if (bytesRead == 0 && fileStream->eof()) {
+        // No more data to read
+    } else if (bytesRead < size * nmemb && fileStream->fail() && !fileStream->eof()) {
+        // Handle read error if necessary
+        std::cerr << "SftpTarget::read_callback: Read error from input file." << std::endl;
+        return CURL_READFUNC_ABORT; // Abort transfer on read error
+    }
+    return bytesRead;
+}
+
+
+SftpTarget::SftpTarget(const std::map<std::string, std::string>& config)
+    : m_curlHandle(nullptr), m_port(22), m_credentialManager(nullptr) {
+    // Ensure m_curlHandle is null
+    m_curlHandle = nullptr;
+    m_credentialManager = std::unique_ptr<CredentialManager>(createPlatformCredentialManager());
+
+    auto itHost = config.find("host");
+    if (itHost != config.end()) {
+        m_host = itHost->second;
+    } else {
+        std::cerr << "SftpTarget: 'host' not found in configuration. Cannot proceed." << std::endl;
+        // Consider throwing an exception or setting an error state
+        return;
+    }
+
+    auto itUser = config.find("username");
+    if (itUser != config.end()) {
+        m_username = itUser->second;
+    } else {
+        std::cerr << "SftpTarget: 'username' not found in configuration. Cannot proceed." << std::endl;
+        // Consider throwing an exception or setting an error state
+        return;
+    }
+    
+    auto itPort = config.find("port");
+    if (itPort != config.end()) {
+        try {
+            m_port = std::stoi(itPort->second);
+        } catch (const std::exception& e) {
+            std::cerr << "SftpTarget: Invalid port number '" << itPort->second << "'. Using default 22. Error: " << e.what() << std::endl;
+            m_port = 22;
+        }
+    } else {
+        // Default port is 22, already set in member initializer list
+         std::cout << "SftpTarget: 'port' not found in configuration, defaulting to 22." << std::endl;
+    }
+
+    QString serviceName = QString("sftp_%1_%2").arg(QString::fromStdString(m_host)).arg(m_port);
+    QString qUsername = QString::fromStdString(m_username);
+
+    auto itPass = config.find("password");
+    if (itPass != config.end() && !itPass->second.empty()) {
+        m_password = itPass->second; // Store for current session
+        QString qPassword = QString::fromStdString(m_password);
+        if (m_credentialManager) {
+            std::cout << "SftpTarget: Password provided in config. Storing with CredentialManager for service: " << serviceName.toStdString() << " user: " << qUsername.toStdString() << std::endl;
+            if (m_credentialManager->storeSecret(serviceName, qUsername, qPassword)) {
+                std::cout << "SftpTarget: Password stored successfully via CredentialManager." << std::endl;
+            } else {
+                std::cerr << "SftpTarget: Failed to store password via CredentialManager." << std::endl;
+            }
+        }
+    } else {
+        if (m_credentialManager) {
+            std::cout << "SftpTarget: No password in config. Attempting to retrieve from CredentialManager for service: " << serviceName.toStdString() << " user: " << qUsername.toStdString() << std::endl;
+            std::optional<QString> retrievedPassword = m_credentialManager->retrieveSecret(serviceName, qUsername);
+            if (retrievedPassword) {
+                m_password = retrievedPassword->toStdString();
+                std::cout << "SftpTarget: Password retrieved successfully from CredentialManager." << std::endl;
+            } else {
+                std::cout << "SftpTarget: Failed to retrieve password from CredentialManager or no password stored." << std::endl;
+                // m_password remains empty, key-based auth or password-less auth might be attempted
+            }
+        } else {
+             std::cerr << "SftpTarget: CredentialManager not available. Cannot store or retrieve password." << std::endl;
+        }
+    }
+
+    auto itPath = config.find("remoteBasePath");
+    if (itPath != config.end()) {
+        m_remoteBasePath = itPath->second;
+    } else {
+        m_remoteBasePath = "/"; // Default to root if not specified
+        std::cout << "SftpTarget: 'remoteBasePath' not found, defaulting to '/'." << std::endl;
+    }
+    
+    auto itPort = config.find("port");
+    if (itPort != config.end()) {
+        try {
+            m_port = std::stoi(itPort->second);
+        } catch (const std::exception& e) {
+            std::cerr << "SftpTarget: Invalid port number '" << itPort->second << "'. Using default 22. Error: " << e.what() << std::endl;
+            m_port = 22;
+        }
+    }
+
+    // Initialize CURL globally if not already done (for thread safety, once per app)
+    // curl_global_init(CURL_GLOBAL_ALL); // This should ideally be in main() or app startup
+    std::cout << "SftpTarget configured for host: " << m_host << ", user: " << m_username << ", path: " << m_remoteBasePath << ", port: " << m_port << std::endl;
+}
+
+SftpTarget::~SftpTarget() {
+    if (m_curlHandle) {
+        curl_easy_cleanup(m_curlHandle);
+        m_curlHandle = nullptr;
+    }
+    // Global cleanup if SftpTarget was the only user (ideally in main() or app shutdown)
+    // curl_global_cleanup(); 
+    std::cout << "SftpTarget destroyed." << std::endl;
+}
+
+bool SftpTarget::beginSession() {
+    // Initialize CURL globally once. This is ideally done in main().
+    // For library code, it's tricky. Assuming it's done elsewhere.
+    // curl_global_init(CURL_GLOBAL_DEFAULT);
+
+    std::cout << "SftpTarget: beginSession() called." << std::endl;
+    if (m_host.empty() || m_username.empty()) {
+        std::cerr << "SftpTarget: Host or username is empty. Cannot begin session." << std::endl;
+        return false;
+    }
+
+    if (m_curlHandle) { // Clean up existing handle if any (e.g. from previous failed session)
+        curl_easy_cleanup(m_curlHandle);
+        m_curlHandle = nullptr;
+    }
+
+    m_curlHandle = curl_easy_init();
+    if (!m_curlHandle) {
+        std::cerr << "SftpTarget: curl_easy_init() failed." << std::endl;
+        return false;
+    }
+
+    CURLcode res;
+
+    // Set username
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_USERNAME, m_username.c_str());
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_USERNAME: " << curl_easy_strerror(res) << std::endl;
+        goto error;
+    }
+
+    // Set password (consider using CURLOPT_SSH_KEYFUNCTION for key-based auth in future)
+    if (!m_password.empty()) {
+        res = curl_easy_setopt(m_curlHandle, CURLOPT_PASSWORD, m_password.c_str());
+        if (res != CURLE_OK) {
+            std::cerr << "SftpTarget: Failed to set CURLOPT_PASSWORD: " << curl_easy_strerror(res) << std::endl;
+            goto error;
+        }
+    } else {
+        // Allow password-less auth (e.g. public key via ssh-agent or known_hosts)
+        // Or set CURLOPT_SSH_AUTH_TYPES to CURLSSH_AUTH_PUBLICKEY, CURLSSH_AUTH_AGENT etc.
+        // For now, rely on libcurl's default behavior if password is not provided.
+        std::cout << "SftpTarget: No password provided. Attempting key-based or agent-based auth." << std::endl;
+    }
+    
+    // Set port
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_PORT, (long)m_port);
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_PORT: " << curl_easy_strerror(res) << std::endl;
+        goto error;
+    }
+
+    // Enable verbose mode for debugging
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_VERBOSE, 1L);
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_VERBOSE: " << curl_easy_strerror(res) << std::endl;
+        // Not a fatal error for functionality, but good to know
+    }
+    
+    // Set a preferred SSH authentication type if needed, e.g., password.
+    // This can help if the server offers multiple types and default selection is problematic.
+    // res = curl_easy_setopt(m_curlHandle, CURLOPT_SSH_AUTH_TYPES, CURLSSH_AUTH_PASSWORD);
+    // if (res != CURLE_OK) {
+    //     std::cerr << "SftpTarget: Failed to set CURLOPT_SSH_AUTH_TYPES: " << curl_easy_strerror(res) << std::endl;
+    //     goto error;
+    // }
+
+
+    std::cout << "SftpTarget: Session begun successfully." << std::endl;
+    return true;
+
+error:
+    if (m_curlHandle) {
+        curl_easy_cleanup(m_curlHandle);
+        m_curlHandle = nullptr;
+    }
+    return false;
+}
+
+bool SftpTarget::sendFile(const std::string& sourceAbsolutePath, const FileMetadata& remoteRelativePathAndSize) {
+    // Assuming remoteRelativePathAndSize is a string "path:size" or just "path" and we get size from source.
+    // For this subtask, let's assume remoteRelativePathAndSize IS the remoteRelativePath.
+    // We'll get size from sourceAbsolutePath.
+    const std::string& remoteRelativePath = remoteRelativePathAndSize; // Treat FileMetadata as remote relative path string
+
+    std::cout << "SftpTarget: sendFile(" << sourceAbsolutePath << ", remote_path: " << remoteRelativePath << ") called." << std::endl;
+    if (!m_curlHandle) {
+        std::cerr << "SftpTarget: Session not begun or curl handle not initialized." << std::endl;
+        return false;
+    }
+
+    std::ifstream sourceFile(sourceAbsolutePath, std::ios::binary);
+    if (!sourceFile.is_open()) {
+        std::cerr << "SftpTarget: Failed to open source file: " << sourceAbsolutePath << std::endl;
+        return false;
+    }
+
+    sourceFile.seekg(0, std::ios::end);
+    curl_off_t fileSize = sourceFile.tellg();
+    sourceFile.seekg(0, std::ios::beg);
+
+    if (fileSize < 0) { // Or == -1, depending on platform for tellg error
+        std::cerr << "SftpTarget: Failed to get size of source file: " << sourceAbsolutePath << std::endl;
+        sourceFile.close();
+        return false;
+    }
+    
+    std::string remoteUrl = "sftp://" + m_host + ":" + std::to_string(m_port);
+    // Ensure m_remoteBasePath always ends with a slash if it's not empty
+    if (!m_remoteBasePath.empty() && m_remoteBasePath.back() != '/') {
+        remoteUrl += "/" + m_remoteBasePath + "/";
+    } else if (m_remoteBasePath.empty() || m_remoteBasePath == "/") {
+        remoteUrl += "/"; // Root path
+         // Remove leading slash from remoteRelativePath if m_remoteBasePath is effectively root or empty
+        if (!remoteRelativePath.empty() && remoteRelativePath.front() == '/') {
+             remoteUrl += remoteRelativePath.substr(1);
+        } else {
+             remoteUrl += remoteRelativePath;
+        }
+    } else { // m_remoteBasePath is not empty and ends with /
+        remoteUrl += m_remoteBasePath;
+        // Remove leading slash from remoteRelativePath if present, as m_remoteBasePath already provides trailing slash
+        if (!remoteRelativePath.empty() && remoteRelativePath.front() == '/') {
+             remoteUrl += remoteRelativePath.substr(1);
+        } else {
+             remoteUrl += remoteRelativePath;
+        }
+    }
+    
+    // Normalize URL: remove double slashes if any, except in "sftp://"
+    size_t doubleSlashPos = remoteUrl.find("//", 6); // Start search after "sftp://"
+    while(doubleSlashPos != std::string::npos) {
+        remoteUrl.replace(doubleSlashPos, 2, "/");
+        doubleSlashPos = remoteUrl.find("//", 6);
+    }
+
+
+    std::cout << "SftpTarget: Uploading to URL: " << remoteUrl << std::endl;
+
+    CURLcode res;
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_URL, remoteUrl.c_str());
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_URL: " << curl_easy_strerror(res) << std::endl;
+        sourceFile.close();
+        return false;
+    }
+
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_UPLOAD, 1L);
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_UPLOAD: " << curl_easy_strerror(res) << std::endl;
+        sourceFile.close();
+        return false;
+    }
+
+    // Option to create remote directories if they don't exist.
+    // CURLFTP_CREATE_DIR_RETRY (2L) will attempt to create dirs and retry if simple MKD fails.
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_FTP_CREATE_MISSING_DIRS, (long)CURLFTP_CREATE_DIR_RETRY);
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_FTP_CREATE_MISSING_DIRS: " << curl_easy_strerror(res) << std::endl;
+        // This might not be fatal, server might already have dirs or not support this. Continue.
+    }
+    
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_READFUNCTION, read_callback);
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_READFUNCTION: " << curl_easy_strerror(res) << std::endl;
+        sourceFile.close();
+        return false;
+    }
+
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_READDATA, &sourceFile);
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_READDATA: " << curl_easy_strerror(res) << std::endl;
+        sourceFile.close();
+        return false;
+    }
+
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_INFILESIZE_LARGE, fileSize);
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_INFILESIZE_LARGE: " << curl_easy_strerror(res) << std::endl;
+        sourceFile.close();
+        return false;
+    }
+
+    res = curl_easy_perform(m_curlHandle);
+    sourceFile.close(); // Close file regardless of performance outcome
+
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: curl_easy_perform() failed for sendFile: " << curl_easy_strerror(res) << std::endl;
+        // Reset options that might interfere with next call on same handle, or rely on setting them fresh
+        curl_easy_setopt(m_curlHandle, CURLOPT_UPLOAD, 0L); // Important to reset after an upload
+        return false;
+    }
+
+    std::cout << "SftpTarget: File sent successfully." << std::endl;
+    // Reset options for next potential call, or ensure they are set explicitly each time.
+    // For safety, reset upload mode.
+    curl_easy_setopt(m_curlHandle, CURLOPT_UPLOAD, 0L);
+    return true;
+}
+
+bool SftpTarget::deleteFile(const std::string& remoteRelativePath) {
+    std::cout << "SftpTarget: deleteFile(" << remoteRelativePath << ") called (stub)" << std::endl;
+    if (!m_curlHandle) {
+        std::cerr << "SftpTarget: Session not begun or curl handle not initialized." << std::endl;
+        return false;
+    }
+    // Actual SFTP delete logic using libcurl (e.g., custom RM command or quote)
+    
+    // Construct full URL
+    std::string remoteUrl = "sftp://" + m_host + ":" + std::to_string(m_port);
+    if (!m_remoteBasePath.empty() && m_remoteBasePath.back() != '/') {
+        remoteUrl += "/" + m_remoteBasePath + "/";
+    } else if (m_remoteBasePath.empty() || m_remoteBasePath == "/"){
+        remoteUrl += "/";
+        if (!remoteRelativePath.empty() && remoteRelativePath.front() == '/') {
+             remoteUrl += remoteRelativePath.substr(1);
+        } else {
+             remoteUrl += remoteRelativePath;
+        }
+    } else {
+        remoteUrl += m_remoteBasePath;
+         if (!remoteRelativePath.empty() && remoteRelativePath.front() == '/') {
+             remoteUrl += remoteRelativePath.substr(1);
+        } else {
+             remoteUrl += remoteRelativePath;
+        }
+    }
+     // Normalize URL: remove double slashes if any, except in "sftp://"
+    size_t doubleSlashPos = remoteUrl.find("//", 6); // Start search after "sftp://"
+    while(doubleSlashPos != std::string::npos) {
+        remoteUrl.replace(doubleSlashPos, 2, "/");
+        doubleSlashPos = remoteUrl.find("//", 6);
+    }
+
+    std::cout << "SftpTarget: Attempting to delete URL: " << remoteUrl << std::endl;
+
+    // To delete a file with SFTP using libcurl, you typically issue a "RM" command.
+    // This is done using CURLOPT_QUOTE or CURLOPT_CUSTOMREQUEST.
+    // For SFTP, it's usually a list of post-transfer QUOTE commands.
+    // A simpler way might be to use a custom request "RM /path/to/file" but this is FTP like.
+    // SFTP delete command is typically "rm \"filepath\""
+    // Let's try with CURLOPT_POSTQUOTE. The commands are executed *after* a transfer.
+    // We need to perform a dummy operation like getting info of the file.
+    // Or, if libcurl supports it directly for SFTP (less common).
+
+    // A common way for SFTP:
+    // 1. Set URL to the file: curl_easy_setopt(m_curlHandle, CURLOPT_URL, remoteUrl.c_str());
+    // 2. Add "RM <remote_file_path_absolute_on_server>" to post-quote list.
+    // The path for RM should be absolute from the SFTP server's root, not relative to current dir.
+    // The URL path component is what we need for RM.
+    std::string remoteFilePathForRm = remoteUrl.substr(remoteUrl.find('/', 7) + 1); // Path after sftp://host:port/
+    // Ensure it doesn't have leading slash if m_remoteBasePath was /
+    if (m_remoteBasePath == "/" || m_remoteBasePath.empty()){
+         if(remoteFilePathForRm.front() == '/') remoteFilePathForRm = remoteFilePathForRm.substr(1);
+    }
+
+
+    std::string rmCommand = "rm \"" + remoteFilePathForRm + "\"";
+    std::cout << "SftpTarget: Delete command: " << rmCommand << std::endl;
+
+    struct curl_slist *headerlist = NULL;
+    headerlist = curl_slist_append(headerlist, rmCommand.c_str());
+
+    CURLcode res;
+    // We must set a URL for the connection to be established. The command acts on this context.
+    // We are not actually transferring data, so a "dummy" operation is needed.
+    // Setting NOBODY is good for this.
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_URL, ("sftp://" + m_host + ":" + std::to_string(m_port) + "/").c_str()); // Connect to root
+    if (res != CURLE_OK) {
+         std::cerr << "SftpTarget: Failed to set CURLOPT_URL for delete: " << curl_easy_strerror(res) << std::endl;
+         curl_slist_free_all(headerlist);
+         return false;
+    }
+    // res = curl_easy_setopt(m_curlHandle, CURLOPT_NOBODY, 1L); // Do not expect a body
+    // if (res != CURLE_OK) {
+    //      std::cerr << "SftpTarget: Failed to set CURLOPT_NOBODY for delete: " << curl_easy_strerror(res) << std::endl;
+    //      curl_slist_free_all(headerlist);
+    //      return false;
+    // }
+
+    // Using CURLOPT_QUOTE for SFTP delete. These are commands executed on the server after the main request.
+    // Since there is no main data transfer for delete, this is a bit of a workaround.
+    // Some SFTP servers might not support this well or require specific syntax.
+    res = curl_easy_setopt(m_curlHandle, CURLOPT_QUOTE, headerlist);
+    if (res != CURLE_OK) {
+        std::cerr << "SftpTarget: Failed to set CURLOPT_QUOTE for delete: " << curl_easy_strerror(res) << std::endl;
+        curl_slist_free_all(headerlist);
+        return false;
+    }
+
+    res = curl_easy_perform(m_curlHandle);
+    curl_slist_free_all(headerlist); // Clean up the command list
+    curl_easy_setopt(m_curlHandle, CURLOPT_QUOTE, NULL); // Reset for next operation
+    // curl_easy_setopt(m_curlHandle, CURLOPT_NOBODY, 0L); 
+
+
+    if (res != CURLE_OK) {
+        // Note: Deleting a non-existent file might also return an error.
+        // Check specific error codes if finer-grained handling is needed.
+        // For example, CURLE_REMOTE_FILE_NOT_FOUND (for FTP, SFTP might differ)
+        std::cerr << "SftpTarget: curl_easy_perform() failed for deleteFile: " << curl_easy_strerror(res) << std::endl;
+        // Try to check specific SFTP errors if available from libcurl/libssh2
+        // For now, any error is a failure.
+        return false;
+    }
+    
+    std::cout << "SftpTarget: File deletion command sent successfully for " << remoteRelativePath << std::endl;
+    return true;
+}
+
+bool SftpTarget::endSession() {
+    std::cout << "SftpTarget: endSession() called." << std::endl;
+    if (m_curlHandle) {
+        curl_easy_cleanup(m_curlHandle);
+        m_curlHandle = nullptr;
+    }
+    // Global cleanup if this was the only user, ideally in main.
+    // curl_global_cleanup();
+    std::cout << "SftpTarget: Session ended." << std::endl;
+    return true;
+}

--- a/backy_x/src/targets/SftpTarget.cpp
+++ b/backy_x/src/targets/SftpTarget.cpp
@@ -5,6 +5,7 @@
 #include <vector>   // For directory creation components
 
 #include <QString> // For service name and password with CredentialManager
+#include "util/CredentialManager.h" // For createPlatformCredentialManager and CredentialManager class
 
 // For libcurl (SFTP operations)
 // Ensure libcurl is installed (e.g., sudo apt-get install libcurl4-openssl-dev)
@@ -109,16 +110,6 @@ SftpTarget::SftpTarget(const std::map<std::string, std::string>& config)
         std::cout << "SftpTarget: 'remoteBasePath' not found, defaulting to '/'." << std::endl;
     }
     
-    auto itPort = config.find("port");
-    if (itPort != config.end()) {
-        try {
-            m_port = std::stoi(itPort->second);
-        } catch (const std::exception& e) {
-            std::cerr << "SftpTarget: Invalid port number '" << itPort->second << "'. Using default 22. Error: " << e.what() << std::endl;
-            m_port = 22;
-        }
-    }
-
     // Initialize CURL globally if not already done (for thread safety, once per app)
     // curl_global_init(CURL_GLOBAL_ALL); // This should ideally be in main() or app startup
     std::cout << "SftpTarget configured for host: " << m_host << ", user: " << m_username << ", path: " << m_remoteBasePath << ", port: " << m_port << std::endl;

--- a/backy_x/src/util/CredentialManager_mac.mm
+++ b/backy_x/src/util/CredentialManager_mac.mm
@@ -24,109 +24,186 @@ public:
     }
 
     bool storeSecret(const QString& service, const QString& username, const QString& secret) override {
-        QByteArray serviceBytes, usernameBytes, secretBytes;
-        OSStatus status = SecKeychainAddGenericPassword(
-            nullptr, // Default keychain
-            static_cast<UInt32>(service.length()), // serviceNameLength
-            qsToCString(service, serviceBytes),    // serviceName
-            static_cast<UInt32>(username.length()),// accountNameLength
-            qsToCString(username, usernameBytes),  // accountName
-            static_cast<UInt32>(secret.toUtf8().length()), // passwordLength (use toUtf8 for byte length)
-            secret.toUtf8().constData(),           // passwordData
-            nullptr                                // itemRef (optional)
-        );
+        CFStringRef cfService = service.toCFString();
+        CFStringRef cfUsername = username.toCFString();
+        QByteArray secretUtf8 = secret.toUtf8();
+        CFDataRef cfSecret = CFDataCreate(kCFAllocatorDefault, (const UInt8*)secretUtf8.constData(), secretUtf8.length());
+
+        if (!cfService || !cfUsername || !cfSecret) {
+            qWarning() << "MacOSCredentialManager: Failed to create CoreFoundation objects.";
+            if (cfService) CFRelease(cfService);
+            if (cfUsername) CFRelease(cfUsername);
+            if (cfSecret) CFRelease(cfSecret);
+            return false;
+        }
+
+        CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        if (!query) {
+            qWarning() << "MacOSCredentialManager: Failed to create query dictionary.";
+            CFRelease(cfService);
+            CFRelease(cfUsername);
+            CFRelease(cfSecret);
+            return false;
+        }
+
+        CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+        CFDictionarySetValue(query, kSecAttrService, cfService);
+        CFDictionarySetValue(query, kSecAttrAccount, cfUsername);
+        CFDictionarySetValue(query, kSecValueData, cfSecret);
+
+        OSStatus status = SecItemAdd(query, nullptr);
 
         if (status == errSecSuccess) {
             qDebug() << "MacOSCredentialManager: Secret stored successfully for service" << service << "user" << username;
+            CFRelease(query);
+            CFRelease(cfService);
+            CFRelease(cfUsername);
+            CFRelease(cfSecret);
             return true;
         } else if (status == errSecDuplicateItem) {
-            // Item already exists, try to update it by deleting and re-adding (simplest update)
-            // A more robust update would use SecKeychainItemModifyAttributesAndData
             qDebug() << "MacOSCredentialManager: Secret already exists for service" << service << "user" << username << ". Attempting to update.";
-            if (deleteSecret(service, username)) { // Delete existing
-                // Re-populate QByteArrays as they might have gone out of scope or their data moved
-                // if deleteSecret was called in a way that created new ones.
-                // For safety, always re-convert before a new API call.
-                QByteArray serviceBytesUpdate, usernameBytesUpdate, secretBytesUpdate;
-                status = SecKeychainAddGenericPassword(
-                    nullptr,
-                    static_cast<UInt32>(service.length()), qsToCString(service, serviceBytesUpdate),
-                    static_cast<UInt32>(username.length()), qsToCString(username, usernameBytesUpdate),
-                    static_cast<UInt32>(secret.toUtf8().length()), secret.toUtf8().constData(), // secret.toUtf8() is safe here
-                    nullptr);
+            
+            // Create a query for deletion (without kSecValueData)
+            CFMutableDictionaryRef deleteQuery = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+            if (!deleteQuery) {
+                qWarning() << "MacOSCredentialManager: Failed to create delete query dictionary.";
+                CFRelease(query); // Original query
+                CFRelease(cfService);
+                CFRelease(cfUsername);
+                CFRelease(cfSecret);
+                return false;
+            }
+            CFDictionarySetValue(deleteQuery, kSecClass, kSecClassGenericPassword);
+            CFDictionarySetValue(deleteQuery, kSecAttrService, cfService);
+            CFDictionarySetValue(deleteQuery, kSecAttrAccount, cfUsername);
+
+            OSStatus deleteStatus = SecItemDelete(deleteQuery);
+            CFRelease(deleteQuery);
+
+            if (deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound) {
+                qDebug() << "MacOSCredentialManager: Existing item deleted or not found. Attempting to re-add.";
+                // Attempt to add the item again
+                status = SecItemAdd(query, nullptr); // query still holds all necessary data including kSecValueData
                 if (status == errSecSuccess) {
                     qDebug() << "MacOSCredentialManager: Secret updated successfully.";
+                    CFRelease(query);
+                    CFRelease(cfService);
+                    CFRelease(cfUsername);
+                    CFRelease(cfSecret);
                     return true;
                 }
             }
-            qWarning() << "MacOSCredentialManager: Failed to update secret. Status:" << status << GetMacOSStatusErrorString(status);
+            qWarning() << "MacOSCredentialManager: Failed to update secret. Delete status:" << GetMacOSStatusErrorString(deleteStatus) << "Add status:" << GetMacOSStatusErrorString(status);
+            CFRelease(query);
+            CFRelease(cfService);
+            CFRelease(cfUsername);
+            CFRelease(cfSecret);
             return false;
         } else {
             qWarning() << "MacOSCredentialManager: Failed to store secret. Status:" << status << GetMacOSStatusErrorString(status);
+            CFRelease(query);
+            CFRelease(cfService);
+            CFRelease(cfUsername);
+            CFRelease(cfSecret);
             return false;
         }
     }
 
     std::optional<QString> retrieveSecret(const QString& service, const QString& username) override {
-        QByteArray serviceBytes, usernameBytes;
-        void *passwordData = nullptr;
-        UInt32 passwordLength = 0;
+        CFStringRef cfService = service.toCFString();
+        CFStringRef cfUsername = username.toCFString();
 
-        OSStatus status = SecKeychainFindGenericPassword(
-            nullptr,                               // Default keychain
-            static_cast<UInt32>(service.length()), // serviceNameLength
-            qsToCString(service, serviceBytes),    // serviceName
-            static_cast<UInt32>(username.length()),// accountNameLength
-            qsToCString(username, usernameBytes),  // accountName
-            &passwordLength,                       // passwordLength (out)
-            &passwordData,                         // passwordData (out)
-            nullptr                                // itemRef (out, optional)
-        );
+        if (!cfService || !cfUsername) {
+            qWarning() << "MacOSCredentialManager: Failed to create CFStringRef for service or username.";
+            if (cfService) CFRelease(cfService);
+            if (cfUsername) CFRelease(cfUsername);
+            return std::nullopt;
+        }
+
+        CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        if (!query) {
+            qWarning() << "MacOSCredentialManager: Failed to create query dictionary for retrieveSecret.";
+            CFRelease(cfService);
+            CFRelease(cfUsername);
+            return std::nullopt;
+        }
+
+        CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+        CFDictionarySetValue(query, kSecAttrService, cfService);
+        CFDictionarySetValue(query, kSecAttrAccount, cfUsername);
+        CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+        CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
+
+        CFTypeRef resultDataRef = nullptr;
+        OSStatus status = SecItemCopyMatching(query, &resultDataRef);
+
+        CFRelease(query);
+        CFRelease(cfService);
+        CFRelease(cfUsername);
 
         if (status == errSecSuccess) {
-            qDebug() << "MacOSCredentialManager: Secret retrieved successfully for service" << service << "user" << username;
-            QString secret = QString::fromUtf8(static_cast<const char*>(passwordData), static_cast<int>(passwordLength));
-            SecKeychainItemFreeContent(nullptr, passwordData); // Free data buffer
-            return secret;
+            if (resultDataRef != nullptr && CFGetTypeID(resultDataRef) == CFDataGetTypeID()) {
+                CFDataRef cfData = (CFDataRef)resultDataRef;
+                QString secret = QString::fromUtf8(
+                    reinterpret_cast<const char*>(CFDataGetBytePtr(cfData)),
+                    static_cast<int>(CFDataGetLength(cfData))
+                );
+                CFRelease(cfData); // resultDataRef is the same as cfData, so release it here
+                qDebug() << "MacOSCredentialManager: Secret retrieved successfully for service" << service << "user" << username;
+                return secret;
+            } else {
+                qWarning() << "MacOSCredentialManager: SecItemCopyMatching returned success but data is not CFDataRef or is null.";
+                if (resultDataRef) CFRelease(resultDataRef); // Release if it's not null but not CFDataRef
+                return std::nullopt;
+            }
         } else if (status == errSecItemNotFound) {
             qDebug() << "MacOSCredentialManager: Secret not found for service" << service << "user" << username;
+            // No data to release for errSecItemNotFound according to docs for SecItemCopyMatching
             return std::nullopt;
         } else {
             qWarning() << "MacOSCredentialManager: Failed to retrieve secret. Status:" << status << GetMacOSStatusErrorString(status);
+            // No data to release on other errors according to docs for SecItemCopyMatching
             return std::nullopt;
         }
     }
 
     bool deleteSecret(const QString& service, const QString& username) override {
-        QByteArray serviceBytes, usernameBytes;
-        SecKeychainItemRef itemRef = nullptr;
-        OSStatus status;
+        CFStringRef cfService = service.toCFString();
+        CFStringRef cfUsername = username.toCFString();
 
-        // First, find the item to get its reference (needed for delete)
-        status = SecKeychainFindGenericPassword(
-            nullptr,
-            static_cast<UInt32>(service.length()), qsToCString(service, serviceBytes),
-            static_cast<UInt32>(username.length()), qsToCString(username, usernameBytes),
-            nullptr, nullptr, // We don't need password data here
-            &itemRef);
+        if (!cfService || !cfUsername) {
+            qWarning() << "MacOSCredentialManager: Failed to create CFStringRef for service or username in deleteSecret.";
+            if (cfService) CFRelease(cfService);
+            if (cfUsername) CFRelease(cfUsername);
+            return false;
+        }
 
-        if (status == errSecSuccess && itemRef != nullptr) {
-            status = SecKeychainItemDelete(itemRef);
-            CFRelease(itemRef); // Release the itemRef whether delete succeeded or not, as we obtained it.
-            if (status == errSecSuccess) {
-                qDebug() << "MacOSCredentialManager: Secret deleted successfully for service" << service << "user" << username;
-                return true;
-            } else {
-                qWarning() << "MacOSCredentialManager: Failed to delete secret. Status:" << status << GetMacOSStatusErrorString(status);
-                return false;
-            }
+        CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        if (!query) {
+            qWarning() << "MacOSCredentialManager: Failed to create query dictionary for deleteSecret.";
+            CFRelease(cfService);
+            CFRelease(cfUsername);
+            return false;
+        }
+
+        CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+        CFDictionarySetValue(query, kSecAttrService, cfService);
+        CFDictionarySetValue(query, kSecAttrAccount, cfUsername);
+
+        OSStatus status = SecItemDelete(query);
+
+        CFRelease(query);
+        CFRelease(cfService);
+        CFRelease(cfUsername);
+
+        if (status == errSecSuccess) {
+            qDebug() << "MacOSCredentialManager: Secret deleted successfully for service" << service << "user" << username;
+            return true;
         } else if (status == errSecItemNotFound) {
             qDebug() << "MacOSCredentialManager: Secret to delete not found for service" << service << "user" << username << "(considered success).";
-            if (itemRef) CFRelease(itemRef); // Still release if somehow itemRef was set but status was errSecItemNotFound
-            return true; // Standard behavior: deleting a non-existent item is often a success.
+            return true; // Deleting a non-existent item is often considered a success.
         } else {
-            qWarning() << "MacOSCredentialManager: Failed to find secret for deletion. Status:" << status << GetMacOSStatusErrorString(status);
-            if (itemRef) CFRelease(itemRef); // Ensure release on other errors too
+            qWarning() << "MacOSCredentialManager: Failed to delete secret. Status:" << status << GetMacOSStatusErrorString(status);
             return false;
         }
     }
@@ -140,8 +217,8 @@ private:
         #if MAC_OS_X_VERSION_MIN_REQUIRED >= 101000
         CFStringRef errorStringRef = SecCopyErrorMessageString(macStatus, NULL);
         if (errorStringRef != NULL) {
-            // QString::fromCFString is deprecated. Use QString::CFStringRefToString.
-            QString errorString = QString::CFStringRefToString(errorStringRef);
+            // Correct way to convert CFStringRef to QString
+            QString errorString = QString::fromCFString(errorStringRef);
             CFRelease(errorStringRef);
             return errorString;
         }

--- a/backy_x/tests/test_scheduler.cpp
+++ b/backy_x/tests/test_scheduler.cpp
@@ -95,7 +95,7 @@ TEST_F(SchedulerTest, SetAndGetTaskProperties) {
 
     QSignalSpy taskChangedSpy(scheduler_, &Scheduler::taskChanged);
 
-    scheduler_->setDailyBackupTask(src, dst, time, enabled);
+    scheduler_->setDailyBackupTask(src, dst, time, enabled, false, QString(), 0, QString(), QString());
 
     EXPECT_EQ(scheduler_->sourcePath(), src);
     EXPECT_EQ(scheduler_->destinationPath(), dst);
@@ -121,7 +121,7 @@ TEST_F(SchedulerTest, SaveAndLoadTask) {
     QTime time(14, 45);
     bool enabled = true;
 
-    scheduler_->setDailyBackupTask(src, dst, time, enabled);
+    scheduler_->setDailyBackupTask(src, dst, time, enabled, false, QString(), 0, QString(), QString());
     // Task is saved by setDailyBackupTask.
 
     // Create a new Scheduler instance using the same settings file
@@ -139,10 +139,10 @@ TEST_F(SchedulerTest, DisableTask) {
     QString dst = "/path/dst";
     QTime time(12, 00);
 
-    scheduler_->setDailyBackupTask(src, dst, time, true); // Enable first
+    scheduler_->setDailyBackupTask(src, dst, time, true, false, QString(), 0, QString(), QString()); // Enable first
     ASSERT_TRUE(scheduler_->isEnabled());
 
-    scheduler_->setDailyBackupTask(src, dst, time, false); // Then disable
+    scheduler_->setDailyBackupTask(src, dst, time, false, false, QString(), 0, QString(), QString()); // Then disable
     EXPECT_FALSE(scheduler_->isEnabled());
 
     // Verify persistence of disabled state
@@ -153,7 +153,7 @@ TEST_F(SchedulerTest, DisableTask) {
 
 TEST_F(SchedulerTest, HandlesEmptyPathsOnSet) {
     // Setting empty paths should be stored as such
-    scheduler_->setDailyBackupTask("", "", QTime(1,1), true);
+    scheduler_->setDailyBackupTask("", "", QTime(1,1), true, false, QString(), 0, QString(), QString());
     EXPECT_EQ(scheduler_->sourcePath(), QString(""));
     EXPECT_EQ(scheduler_->destinationPath(), QString(""));
 

--- a/backy_x/tests/test_sftp_target.cpp
+++ b/backy_x/tests/test_sftp_target.cpp
@@ -1,0 +1,267 @@
+#include "gtest/gtest.h"
+#include "targets/SftpTarget.h" // The class we're testing
+#include "core/IStorageTarget.h" // For FileMetadata type
+// #include "util/CredentialManager.h" // Not directly mocking here, but SftpTarget uses it.
+
+#include <fstream>  // For std::ofstream to create dummy files
+#include <iostream> // For std::cerr in tests if needed
+#include <filesystem> // For std::filesystem::temp_directory_path, ::remove
+#include <map>
+#include <string>
+
+// Helper function to create a dummy file for testing uploads
+std::string createDummyFile(const std::string& fileName, size_t size) {
+    std::filesystem::path tempFilePath = std::filesystem::temp_directory_path() / fileName;
+    std::ofstream outfile(tempFilePath, std::ios::binary);
+    if (outfile.is_open()) {
+        std::vector<char> buffer(size, 'A'); // Fill with 'A's
+        outfile.write(buffer.data(), size);
+        outfile.close();
+        return tempFilePath.string();
+    }
+    return ""; // Return empty if failed
+}
+
+class SftpTargetTest : public ::testing::Test {
+protected:
+    std::map<std::string, std::string> baseConfig;
+    std::string dummyFileName = "test_upload_file.txt";
+    std::string dummyFilePath;
+
+    void SetUp() override {
+        // Basic valid configuration
+        baseConfig["host"] = "localhost"; // Default, will fail for actual connection but fine for some offline tests
+        baseConfig["username"] = "testuser";
+        baseConfig["password"] = "testpass"; // SftpTarget will try to store this
+        baseConfig["remoteBasePath"] = "backy_x_tests"; // Corrected typo here
+        baseConfig["port"] = "2222"; // Non-standard port often used for testing
+
+        // Create a dummy file for tests that need one
+        dummyFilePath = createDummyFile(dummyFileName, 1024); // 1KB file
+        ASSERT_FALSE(dummyFilePath.empty()) << "Failed to create dummy file for testing.";
+    }
+
+    void TearDown() override {
+        // Remove the dummy file
+        if (!dummyFilePath.empty()) {
+            std::filesystem::remove(dummyFilePath);
+        }
+    }
+};
+
+// --- Test Construction ---
+TEST_F(SftpTargetTest, ConstructorValidMinimalConfig) {
+    std::map<std::string, std::string> config = {
+        {"host", "sftphost"},
+        {"username", "user"}
+        // Password and remoteBasePath are optional for construction, SftpTarget might try to get pass from CM
+    };
+    SftpTarget target(config);
+    // No direct way to check members without getters or friend class,
+    // but constructor should not crash or throw.
+    // SftpTarget logs if essential members are missing, which is a side effect.
+    SUCCEED(); // If it constructs without error
+}
+
+TEST_F(SftpTargetTest, ConstructorMissingHost) {
+    std::map<std::string, std::string> config = {
+        {"username", "user"}
+    };
+    // SftpTarget constructor logs to cerr if host is missing.
+    // We can't easily capture cerr with gtest without more setup.
+    // For now, just expect it not to crash.
+    // A more robust test would involve checking an error state if SftpTarget had one.
+    SftpTarget target(config);
+    // If SftpTarget set an internal error flag, we'd check it here.
+    // For now, we're relying on its internal logging for this case.
+    // The `beginSession` will fail later, which is an indirect check.
+    EXPECT_FALSE(target.beginSession()) << "beginSession should fail if host was missing in config.";
+}
+
+TEST_F(SftpTargetTest, ConstructorMissingUsername) {
+    std::map<std::string, std::string> config = {
+        {"host", "sftphost"}
+    };
+    SftpTarget target(config);
+    EXPECT_FALSE(target.beginSession()) << "beginSession should fail if username was missing in config.";
+}
+
+TEST_F(SftpTargetTest, ConstructorInvalidPort) {
+    std::map<std::string, std::string> config = {
+        {"host", "sftphost"},
+        {"username", "user"},
+        {"port", "notAPort"}
+    };
+    // SftpTarget constructor logs error and defaults to 22.
+    SftpTarget target(config);
+    // No direct way to check port without getter, but it should not crash.
+    SUCCEED();
+}
+
+// --- Offline Behavior Tests ---
+TEST_F(SftpTargetTest, BeginSessionInvalidHost) {
+    std::map<std::string, std::string> config = baseConfig;
+    config["host"] = "nonexistent.invalid.host.for.testing"; // Definitely not resolvable
+    SftpTarget target(config);
+    EXPECT_FALSE(target.beginSession());
+}
+
+TEST_F(SftpTargetTest, EndSessionNoBegin) {
+    SftpTarget target(baseConfig);
+    // endSession should be safe to call even if beginSession was not called or failed
+    // SftpTarget's endSession currently returns true even if no handle exists.
+    EXPECT_TRUE(target.endSession());
+}
+
+TEST_F(SftpTargetTest, SendFileNoSession) {
+    SftpTarget target(baseConfig);
+    // Attempt to send file without calling beginSession
+    EXPECT_FALSE(target.sendFile(dummyFilePath, "remote_test_file.txt")) 
+        << "sendFile should fail if beginSession was not called.";
+}
+
+TEST_F(SftpTargetTest, SendFileAfterFailedBeginSession) {
+    std::map<std::string, std::string> config = baseConfig;
+    config["host"] = ""; // Ensure beginSession fails
+    SftpTarget target(config);
+    ASSERT_FALSE(target.beginSession()); // Precondition: beginSession failed
+    EXPECT_FALSE(target.sendFile(dummyFilePath, "remote_test_file.txt")) 
+        << "sendFile should fail if beginSession failed.";
+}
+
+TEST_F(SftpTargetTest, SendNonExistentLocalFile) {
+    SftpTarget target(baseConfig);
+    // We can't fully test beginSession offline without a mock server,
+    // so we assume it might "succeed" in setting up curl handle,
+    // but sendFile should fail on local file issues.
+    // For a true offline test, we'd need to ensure beginSession returns false.
+    // Let's use a config that makes beginSession likely to fail.
+    baseConfig["host"] = "invalid-host-for-offline-test";
+    SftpTarget offlineTarget(baseConfig);
+    
+    // Even if beginSession were to somehow pass in a test setup (e.g. mock curl),
+    // the file operation itself should fail.
+    // If beginSession fails (as it should with invalid host), sendFile also fails.
+    if (!offlineTarget.beginSession()) { // This is expected
+         EXPECT_FALSE(offlineTarget.sendFile("non_existent_local_file.txt", "remote.txt"))
+            << "sendFile should fail if beginSession failed.";
+    } else { // Should not happen with invalid host, but if it did:
+        EXPECT_FALSE(offlineTarget.sendFile("non_existent_local_file.txt", "remote.txt"))
+            << "sendFile should fail for non-existent local file even if session began.";
+        offlineTarget.endSession();
+    }
+}
+
+// --- Online Behavior Tests (Placeholders) ---
+// These tests require a live SFTP server.
+// Configure environment variables or a local config file for credentials and server details.
+// For example: SFTP_TEST_HOST, SFTP_TEST_PORT, SFTP_TEST_USER, SFTP_TEST_PASSWORD, SFTP_TEST_BASEPATH
+
+class SftpTargetOnlineTest : public SftpTargetTest {
+protected:
+    std::map<std::string, std::string> onlineConfig;
+    bool configured = false;
+
+    void SetUp() override {
+        SftpTargetTest::SetUp(); // Call base SetUp for dummy file
+
+        const char* host = std::getenv("SFTP_TEST_HOST");
+        const char* port_str = std::getenv("SFTP_TEST_PORT");
+        const char* user = std::getenv("SFTP_TEST_USER");
+        const char* pass = std::getenv("SFTP_TEST_PASSWORD");
+        const char* path = std::getenv("SFTP_TEST_BASEPATH");
+
+        if (host && port_str && user && pass && path) {
+            onlineConfig["host"] = host;
+            onlineConfig["port"] = port_str;
+            onlineConfig["username"] = user;
+            onlineConfig["password"] = pass;
+            onlineConfig["remoteBasePath"] = path;
+            configured = true;
+        } else {
+            std::cout << "SFTP Online Test: Environment variables SFTP_TEST_HOST, _PORT, _USER, _PASSWORD, _BASEPATH not set. Skipping online tests." << std::endl;
+        }
+    }
+};
+
+TEST_F(SftpTargetOnlineTest, ConnectDisconnect) {
+    if (!configured) {
+        GTEST_SKIP() << "SFTP server not configured. Skipping test.";
+        return;
+    }
+    SftpTarget target(onlineConfig);
+    EXPECT_TRUE(target.beginSession());
+    EXPECT_TRUE(target.endSession());
+}
+
+TEST_F(SftpTargetOnlineTest, UploadSingleFile) {
+    if (!configured) {
+        GTEST_SKIP() << "SFTP server not configured. Skipping test.";
+        return;
+    }
+    SftpTarget target(onlineConfig);
+    ASSERT_TRUE(target.beginSession());
+    std::string remoteFileName = "uploaded_test_file.txt";
+    EXPECT_TRUE(target.sendFile(dummyFilePath, remoteFileName));
+    // TODO: Add verification step (e.g., list directory or try to download)
+    // For now, also test delete.
+    EXPECT_TRUE(target.deleteFile(remoteFileName)) << "Failed to delete the uploaded file. Manual cleanup may be required.";
+    EXPECT_TRUE(target.endSession());
+}
+
+TEST_F(SftpTargetOnlineTest, UploadToNonExistentDirectoryAndCreate) {
+    if (!configured) {
+        GTEST_SKIP() << "SFTP server not configured. Skipping test.";
+        return;
+    }
+    SftpTarget target(onlineConfig);
+    ASSERT_TRUE(target.beginSession());
+    std::string remotePathWithDir = "new_test_dir/another_uploaded_test_file.txt";
+    EXPECT_TRUE(target.sendFile(dummyFilePath, remotePathWithDir)) 
+        << "Failed to upload file, possibly due to directory creation failure.";
+    
+    // Cleanup: delete the file, then attempt to delete the directory.
+    // Note: libcurl SFTP delete is for files. Directory deletion might need different commands (e.g. "rmdir")
+    // and might fail if directory is not empty.
+    EXPECT_TRUE(target.deleteFile(remotePathWithDir)) << "Failed to delete the uploaded file in new_test_dir.";
+    // Add a step to remove "new_test_dir" if possible/needed, or ensure server cleans it up.
+    // For now, we rely on CURLOPT_FTP_CREATE_MISSING_DIRS for creation.
+    // Deleting directories is more complex with libcurl's SFTP file-oriented commands.
+    // SftpTarget::deleteFile is also file-oriented.
+    EXPECT_TRUE(target.endSession());
+}
+
+TEST_F(SftpTargetOnlineTest, AuthenticationFailure) {
+    if (!configured) {
+        GTEST_SKIP() << "SFTP server not configured. Skipping test.";
+        return;
+    }
+    std::map<std::string, std::string> badConfig = onlineConfig;
+    badConfig["password"] = "wrongpassword";
+    SftpTarget target(badConfig);
+    EXPECT_FALSE(target.beginSession()) << "beginSession should fail with incorrect password.";
+}
+
+TEST_F(SftpTargetOnlineTest, DeleteNonExistentFile) {
+     if (!configured) {
+        GTEST_SKIP() << "SFTP server not configured. Skipping test.";
+        return;
+    }
+    SftpTarget target(onlineConfig);
+    ASSERT_TRUE(target.beginSession());
+    // SftpTarget::deleteFile returns true for errSecItemNotFound (macOS keychain)
+    // For SFTP, libcurl might return an error for file not found.
+    // Current SftpTarget::deleteFile returns true if curl_easy_perform is OK.
+    // A robust SFTP delete would check server response codes.
+    // Let's assume for now it should return false if the file truly isn't there and RM fails.
+    // However, some servers might return success for RM on non-existent file.
+    // This test's expectation might need adjustment based on typical server behavior.
+    EXPECT_FALSE(target.deleteFile("this_file_should_not_exist_ever.txt"));
+    EXPECT_TRUE(target.endSession());
+}
+
+// Main function for Google Test (if not linking with gtest_main)
+// int main(int argc, char **argv) {
+//     ::testing::InitGoogleTest(&argc, argv);
+//     return RUN_ALL_TESTS();
+// }


### PR DESCRIPTION
- I replaced deprecated SecKeychain APIs with modern SecItem equivalents in CredentialManager_mac.mm.
- This resolves warnings related to deprecated functions on macOS.
- I corrected the CFStringRef to QString conversion in GetMacOSStatusErrorString, fixing a compilation error.
- I also updated comments and logging messages to reflect the API changes.