### PR TITLE
Fix crash when deleting SFTP files

### DIFF
--- a/backy_x/src/targets/SftpTarget.cpp
+++ b/backy_x/src/targets/SftpTarget.cpp
@@ -480,10 +480,11 @@ bool SftpTarget::deleteFile(const std::string& remotePath) {
     curl_easy_setopt(m_curlHandle, CURLOPT_HTTPGET, 0L);
     curl_easy_setopt(m_curlHandle, CURLOPT_POST, 0L);
 
-    // Reset write/read functions and data, just in case they were set by another operation
-    // and not properly cleared if that operation failed before its usual cleanup.
-    curl_easy_setopt(m_curlHandle, CURLOPT_WRITEFUNCTION, NULL);
-    curl_easy_setopt(m_curlHandle, CURLOPT_WRITEDATA, NULL);
+    // Reset write/read functions and data. We keep our no-op callbacks instead of
+    // using libcurl's defaults to avoid writing to stdout/stderr, which may be
+    // invalid in the GUI environment.
+    curl_easy_setopt(m_curlHandle, CURLOPT_WRITEFUNCTION, noop_write_callback);
+    curl_easy_setopt(m_curlHandle, CURLOPT_WRITEDATA, nullptr);
     curl_easy_setopt(m_curlHandle, CURLOPT_READFUNCTION, NULL);
     curl_easy_setopt(m_curlHandle, CURLOPT_READDATA, NULL);
 


### PR DESCRIPTION
## Summary
- keep noop write callback when performing DELETE over SFTP

## Testing
- `cmake ..` *(fails: Could not find Qt6)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcd2504dc8321a0c32761b3725873