### PR TITLE
Add multiple daily backup times

### DIFF
--- a/backy_x/include/core/Scheduler.h
+++ b/backy_x/include/core/Scheduler.h
@@ -6,6 +6,7 @@
 #include <QString> // For source/destination paths
 #include <QTimer>
 #include <QSettings> // For persistence
+#include <QList>
 
 // Forward declaration if BackupTask struct becomes complex, for now just basic info
 // struct BackupTask {
@@ -25,14 +26,14 @@ public:
 
     // Configures the daily backup task
     // Configures the daily backup task
-    void setDailyBackupTask(const QString& sourcePath, 
+    void setDailyBackupTask(const QString& sourcePath,
                             const QString& destinationPathOrIdentifier, // For local, it's path. For SFTP, it might be a descriptive string or empty.
-                            const QTime& scheduledTime, 
-                            bool enabled, 
-                            bool isSftpMode, 
-                            const QString& sftpHost = QString(), 
-                            int sftpPort = 22, 
-                            const QString& sftpUsername = QString(), 
+                            const QList<QTime>& scheduledTimes,
+                            bool enabled,
+                            bool isSftpMode,
+                            const QString& sftpHost = QString(),
+                            int sftpPort = 22,
+                            const QString& sftpUsername = QString(),
                             const QString& sftpRemotePath = QString(),
                             bool isGcsMode = false, // New GCS parameter
                             const QString& gcsBucketName = QString(), // New GCS parameter
@@ -43,7 +44,7 @@ public:
     
     QString sourcePath() const;
     QString destinationPath() const; // For local mode, or descriptive identifier for SFTP
-    QTime scheduledTime() const;
+    QList<QTime> scheduledTimes() const;
     bool isEnabled() const;
     bool isSftpMode() const; // Getter for SFTP mode
 
@@ -75,7 +76,7 @@ private:
 
     QString m_currentSourcePath;
     QString m_currentDestinationPath; // For local, this is the path. For SFTP, this might be a placeholder or unused if SFTP details are separate.
-    QTime m_currentScheduledTime;
+    QList<QTime> m_scheduledTimes;
     bool m_taskEnabled;
     
     // SFTP specific settings
@@ -97,7 +98,7 @@ private:
     const QString SETTINGS_GROUP = "Scheduler";
     const QString KEY_SOURCE_PATH = "sourcePath";
     const QString KEY_DEST_PATH = "destinationPath"; // Or "destinationIdentifier"
-    const QString KEY_SCHEDULED_TIME = "scheduledTime";
+    const QString KEY_SCHEDULED_TIMES = "scheduledTimes";
     const QString KEY_TASK_ENABLED = "taskEnabled";
     const QString KEY_IS_SFTP_MODE = "isSftpMode";
     const QString KEY_SFTP_HOST = "sftpHost";

--- a/backy_x/src/core/Scheduler.cpp
+++ b/backy_x/src/core/Scheduler.cpp
@@ -5,13 +5,12 @@
 
 Scheduler::Scheduler(const QString& settingsFilePath, QObject *parent)
     : QObject(parent),
-      m_taskEnabled(false), // Renamed variables
-      m_isSftpMode(false),  // Initialize new SFTP flag
-      m_sftpPort(22),       // Default SFTP port
-      m_isGcsMode(false),   // Initialize GCS flag
-      // m_gcsBucketName and m_gcsObjectPrefix are QStrings, default constructor makes them empty
-      m_dailyTimer(new QTimer(this)), // Renamed
-      m_settings(nullptr)      // Renamed
+      m_taskEnabled(false),
+      m_isSftpMode(false),
+      m_sftpPort(22),
+      m_isGcsMode(false),
+      m_dailyTimer(new QTimer(this)),
+      m_settings(nullptr)
 {
     if (settingsFilePath.isEmpty()) {
         if (QCoreApplication::organizationName().isEmpty()) {
@@ -35,10 +34,10 @@ Scheduler::~Scheduler() {
     // m_dailyTimer and m_settings are children, Qt handles cleanup.
 }
 
-void Scheduler::setDailyBackupTask(const QString& sourcePath, 
-                                   const QString& destinationPathOrIdentifier, 
-                                   const QTime& scheduledTime, 
-                                   bool enabled, 
+void Scheduler::setDailyBackupTask(const QString& sourcePath,
+                                   const QString& destinationPathOrIdentifier,
+                                   const QList<QTime>& scheduledTimes,
+                                   bool enabled,
                                    bool isSftpMode,
                                    const QString& sftpHost,
                                    int sftpPort,
@@ -49,7 +48,7 @@ void Scheduler::setDailyBackupTask(const QString& sourcePath,
                                    const QString& gcsObjectPrefix) {
     m_currentSourcePath = sourcePath;
     m_currentDestinationPath = destinationPathOrIdentifier; // Store identifier or local path
-    m_currentScheduledTime = scheduledTime;
+    m_scheduledTimes = scheduledTimes;
     m_taskEnabled = enabled;
     m_isSftpMode = isSftpMode;
     m_isGcsMode = isGcsMode;
@@ -98,7 +97,12 @@ void Scheduler::loadTask() {
     m_settings->beginGroup(SETTINGS_GROUP);
     m_currentSourcePath = m_settings->value(KEY_SOURCE_PATH, "").toString();
     m_currentDestinationPath = m_settings->value(KEY_DEST_PATH, "").toString();
-    m_currentScheduledTime = m_settings->value(KEY_SCHEDULED_TIME, QTime(23, 0)).toTime();
+    QStringList timeStrings = m_settings->value(KEY_SCHEDULED_TIMES, QStringList({"23:00"})).toStringList();
+    m_scheduledTimes.clear();
+    for (const QString& ts : timeStrings) {
+        QTime t = QTime::fromString(ts, "HH:mm");
+        if (t.isValid()) m_scheduledTimes.append(t);
+    }
     m_taskEnabled = m_settings->value(KEY_TASK_ENABLED, false).toBool();
     m_isSftpMode = m_settings->value(KEY_IS_SFTP_MODE, false).toBool();
     m_isGcsMode = m_settings->value(KEY_IS_GCS_MODE, false).toBool();
@@ -119,7 +123,7 @@ void Scheduler::loadTask() {
     qDebug() << "Scheduler: Loaded task -"
              << "Source:" << m_currentSourcePath
              << "Dest/ID:" << m_currentDestinationPath
-             << "Time:" << m_currentScheduledTime.toString("HH:mm")
+             << "Times:" << m_scheduledTimes
              << "Enabled:" << m_taskEnabled
              << "SFTP Mode:" << m_isSftpMode
              << "GCS Mode:" << m_isGcsMode;
@@ -138,7 +142,11 @@ void Scheduler::saveTask() {
     m_settings->beginGroup(SETTINGS_GROUP);
     m_settings->setValue(KEY_SOURCE_PATH, m_currentSourcePath);
     m_settings->setValue(KEY_DEST_PATH, m_currentDestinationPath);
-    m_settings->setValue(KEY_SCHEDULED_TIME, m_currentScheduledTime);
+    QStringList timeStrings;
+    for (const QTime& t : m_scheduledTimes) {
+        timeStrings << t.toString("HH:mm");
+    }
+    m_settings->setValue(KEY_SCHEDULED_TIMES, timeStrings);
     m_settings->setValue(KEY_TASK_ENABLED, m_taskEnabled);
     m_settings->setValue(KEY_IS_SFTP_MODE, m_isSftpMode);
     m_settings->setValue(KEY_IS_GCS_MODE, m_isGcsMode);
@@ -186,7 +194,7 @@ void Scheduler::saveTask() {
     qDebug() << "Scheduler: Saved task -"
              << "Source:" << m_currentSourcePath
              << "Dest/ID:" << m_currentDestinationPath
-             << "Time:" << m_currentScheduledTime.toString("HH:mm")
+             << "Times:" << m_scheduledTimes
              << "Enabled:" << m_taskEnabled
              << "SFTP Mode:" << m_isSftpMode
              << "GCS Mode:" << m_isGcsMode;
@@ -204,33 +212,38 @@ void Scheduler::scheduleNextCheck() {
     bool gcsConfigOk = !m_isGcsMode || !m_gcsBucketName.isEmpty(); // Object prefix can be empty
     bool localConfigOk = (!m_isSftpMode && !m_isGcsMode) ? !m_currentDestinationPath.isEmpty() : true; // Only check if local mode
 
-    if (!m_taskEnabled || !m_currentScheduledTime.isValid() || m_currentSourcePath.isEmpty() || !sftpConfigOk || !gcsConfigOk || !localConfigOk) {
+    if (!m_taskEnabled || m_scheduledTimes.isEmpty() || m_currentSourcePath.isEmpty() || !sftpConfigOk || !gcsConfigOk || !localConfigOk) {
         qDebug() << "Scheduler: Task disabled or not fully configured for the current mode, not scheduling.";
         if (!m_taskEnabled) qDebug() << "Reason: Task not enabled.";
-        if (!m_currentScheduledTime.isValid()) qDebug() << "Reason: Scheduled time invalid.";
+        if (m_scheduledTimes.isEmpty()) qDebug() << "Reason: No scheduled times.";
         if (m_currentSourcePath.isEmpty()) qDebug() << "Reason: Source path empty.";
         if (m_isSftpMode && !sftpConfigOk) qDebug() << "Reason: SFTP mode active but not fully configured.";
         if (m_isGcsMode && !gcsConfigOk) qDebug() << "Reason: GCS mode active but bucket name empty.";
         if (!m_isSftpMode && !m_isGcsMode && !localConfigOk) qDebug() << "Reason: Local mode active but destination path empty.";
         return;
     }
-
     QDateTime currentDateTime = QDateTime::currentDateTime();
-    QDateTime scheduledDateTime(currentDateTime.date(), m_currentScheduledTime); // Renamed variable
-
-    if (scheduledDateTime < currentDateTime) {
-        scheduledDateTime = scheduledDateTime.addDays(1);
+    QDateTime nextDateTime;
+    bool found = false;
+    for (const QTime& t : m_scheduledTimes) {
+        if (!t.isValid()) continue;
+        QDateTime candidate(currentDateTime.date(), t);
+        if (candidate < currentDateTime)
+            candidate = candidate.addDays(1);
+        if (!found || candidate < nextDateTime) {
+            nextDateTime = candidate;
+            found = true;
+        }
     }
+    if (!found) return;
 
-    qint64 msecsUntilScheduled = currentDateTime.msecsTo(scheduledDateTime);
-    if (msecsUntilScheduled < 0) { 
-        msecsUntilScheduled = 0; 
-    }
-    
-    m_dailyTimer->setSingleShot(true); // Renamed variable
-    m_dailyTimer->start(msecsUntilScheduled); // Renamed variable
+    qint64 msecsUntilScheduled = currentDateTime.msecsTo(nextDateTime);
+    if (msecsUntilScheduled < 0) msecsUntilScheduled = 0;
 
-    qDebug() << "Scheduler: Next check scheduled for:" << scheduledDateTime.toString("yyyy-MM-dd HH:mm:ss")
+    m_dailyTimer->setSingleShot(true);
+    m_dailyTimer->start(msecsUntilScheduled);
+
+    qDebug() << "Scheduler: Next check scheduled for:" << nextDateTime.toString("yyyy-MM-dd HH:mm:ss")
              << "in" << msecsUntilScheduled / 1000.0 << "seconds.";
 }
 
@@ -239,15 +252,15 @@ void Scheduler::checkScheduledTime() {
     bool gcsConfigOk = !m_isGcsMode || !m_gcsBucketName.isEmpty(); // Object prefix can be empty
     bool localConfigOk = (!m_isSftpMode && !m_isGcsMode) ? !m_currentDestinationPath.isEmpty() : true;
 
-    if (!m_taskEnabled || !m_currentScheduledTime.isValid() || m_currentSourcePath.isEmpty() || !sftpConfigOk || !gcsConfigOk || !localConfigOk) {
+    if (!m_taskEnabled || m_scheduledTimes.isEmpty() || m_currentSourcePath.isEmpty() || !sftpConfigOk || !gcsConfigOk || !localConfigOk) {
         qDebug() << "Scheduler: Check time called, but task is not active or fully configured for the current mode.";
-        scheduleNextCheck(); 
+        scheduleNextCheck();
         return;
     }
 
     QTime currentTime = QTime::currentTime();
     qDebug() << "Scheduler: Timer fired! Current time:" << currentTime.toString("HH:mm:ss")
-             << "Scheduled:" << m_currentScheduledTime.toString("HH:mm"); // Renamed variable
+             << "Times:" << m_scheduledTimes;
 
     emit backupTaskTriggered(m_currentSourcePath, m_currentDestinationPath); // Renamed variables
     
@@ -263,8 +276,8 @@ QString Scheduler::destinationPath() const {
     return m_currentDestinationPath; // Renamed variable (this is dest path for local, or identifier for SFTP)
 }
 
-QTime Scheduler::scheduledTime() const {
-    return m_currentScheduledTime; // Renamed variable
+QList<QTime> Scheduler::scheduledTimes() const {
+    return m_scheduledTimes;
 }
 
 bool Scheduler::isEnabled() const {

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -39,6 +39,9 @@ MainWindow::MainWindow(QWidget *parent)
       destinationDirEdit_(nullptr),
       destinationDirButton_(nullptr),
       backupTimeEdit_(nullptr),
+      addTimeButton_(nullptr),
+      timeListWidget_(nullptr),
+      removeTimeButton_(nullptr),
       applyScheduleButton_(nullptr),
       runBackupButton_(nullptr),
       logDisplay_(nullptr),
@@ -200,16 +203,27 @@ void MainWindow::setupUI() {
 
     QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Controls"));
     QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
-    scheduleLayout->addWidget(new QLabel(tr("Daily Backup Time:")), 0, 0);
+    scheduleLayout->addWidget(new QLabel(tr("Backup Time:")), 0, 0);
     backupTimeEdit_ = new QTimeEdit();
     backupTimeEdit_->setDisplayFormat("HH:mm");
-    scheduleLayout->addWidget(backupTimeEdit_, 0, 1, 1, 2);
+    scheduleLayout->addWidget(backupTimeEdit_, 0, 1);
+    addTimeButton_ = new QPushButton(tr("Add"));
+    scheduleLayout->addWidget(addTimeButton_, 0, 2);
+    connect(addTimeButton_, &QPushButton::clicked, this, &MainWindow::onAddBackupTimeClicked);
+
+    scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 1, 0, 1, 3);
+    timeListWidget_ = new QListWidget();
+    scheduleLayout->addWidget(timeListWidget_, 2, 0, 1, 3);
+    removeTimeButton_ = new QPushButton(tr("Remove Selected"));
+    scheduleLayout->addWidget(removeTimeButton_, 3, 0, 1, 3);
+    connect(removeTimeButton_, &QPushButton::clicked, this, &MainWindow::onRemoveBackupTimeClicked);
+
     applyScheduleButton_ = new QPushButton(tr("Apply Schedule"));
     connect(applyScheduleButton_, &QPushButton::clicked, this, &MainWindow::applySchedule);
-    scheduleLayout->addWidget(applyScheduleButton_, 1, 0, 1, 3);
+    scheduleLayout->addWidget(applyScheduleButton_, 4, 0, 1, 3);
     runBackupButton_ = new QPushButton(tr("Run Backup Now"));
     connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
-    scheduleLayout->addWidget(runBackupButton_, 2, 0, 1, 3);
+    scheduleLayout->addWidget(runBackupButton_, 5, 0, 1, 3);
     mainLayout->addWidget(scheduleGroupBox);
 
     mainLayout->addWidget(new QLabel(tr("Logs:")));
@@ -284,18 +298,35 @@ void MainWindow::selectDestinationDirectory() {
     }
 }
 
+void MainWindow::onAddBackupTimeClicked() {
+    QTime t = backupTimeEdit_->time();
+    if (!t.isValid()) return;
+    QString text = t.toString("HH:mm");
+    if (timeListWidget_->findItems(text, Qt::MatchExactly).isEmpty()) {
+        timeListWidget_->addItem(text);
+    }
+}
+
+void MainWindow::onRemoveBackupTimeClicked() {
+    qDeleteAll(timeListWidget_->selectedItems());
+}
+
 void MainWindow::applySchedule() {
     QString sourcePath = sourceDirEdit_->text();
-    QTime backupTime = backupTimeEdit_->time();
+    QList<QTime> times;
+    for (int i = 0; i < timeListWidget_->count(); ++i) {
+        QTime t = QTime::fromString(timeListWidget_->item(i)->text(), "HH:mm");
+        if (t.isValid()) times.append(t);
+    }
 
     if (sourcePath.isEmpty()) {
         QMessageBox::warning(this, tr("Configuration Error"), tr("Source path cannot be empty."));
         updateLog("Error: Failed to apply schedule. Source path empty.");
         return;
     }
-     if (!backupTime.isValid()) {
-        QMessageBox::warning(this, tr("Configuration Error"), tr("The selected backup time is invalid."));
-        updateLog("Error: Failed to apply schedule. Invalid time.");
+    if (times.isEmpty()) {
+        QMessageBox::warning(this, tr("Configuration Error"), tr("At least one backup time must be added."));
+        updateLog("Error: Failed to apply schedule. No times added.");
         return;
     }
 
@@ -312,12 +343,13 @@ void MainWindow::applySchedule() {
             updateLog("Error: Failed to apply schedule for Local Backup. Destination path empty.");
             return;
         }
-        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, backupTime, true,
+        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, times, true,
                                        false, QString(),      // sftpHost is QString
                                        0, QString(), QString(), false, // isGcsMode is bool
                                        QString(), QString());
-        updateLog(QString("Schedule applied for Local Backup: %1 to %2 at %3")
-                      .arg(sourcePath, effectiveDestPathOrIdentifier, backupTime.toString("HH:mm")));
+        updateLog(QString("Schedule applied for Local Backup: %1 to %2 with %3 times")
+                      .arg(sourcePath, effectiveDestPathOrIdentifier)
+                      .arg(times.size()));
 
     } else if (sftpMode) {
         if (sftpHostLineEdit_->text().isEmpty() || sftpUsernameLineEdit_->text().isEmpty() || sftpRemotePathLineEdit_->text().isEmpty()) {
@@ -337,14 +369,15 @@ void MainWindow::applySchedule() {
                 m_credentialManager->deleteSecret(serviceName, qUsername);
             }
         }
-        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, backupTime, true,
+        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, times, true,
                                        true, sftpHostLineEdit_->text(), // sftpHost
-                                       sftpPortLineEdit_->text().toInt(), 
-                                       sftpUsernameLineEdit_->text(), 
+                                       sftpPortLineEdit_->text().toInt(),
+                                       sftpUsernameLineEdit_->text(),
                                        sftpRemotePathLineEdit_->text(),
                                        false, QString(), QString()); // isGcsMode, gcsBucketName, gcsObjectPrefix
-        updateLog(QString("Schedule applied for SFTP Backup: %1 to %2 at %3")
-                      .arg(sourcePath, effectiveDestPathOrIdentifier, backupTime.toString("HH:mm")));
+        updateLog(QString("Schedule applied for SFTP Backup: %1 to %2 with %3 times")
+                      .arg(sourcePath, effectiveDestPathOrIdentifier)
+                      .arg(times.size()));
 
     } else if (gcsMode) {
         QString bucketName = gcsBucketNameLineEdit_->text();
@@ -355,12 +388,13 @@ void MainWindow::applySchedule() {
             return;
         }
         effectiveDestPathOrIdentifier = QString("gcs://%1").arg(bucketName);
-        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, backupTime, true,
+        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, times, true,
                                        false, QString(),      // sftpHost is QString
                                        0, QString(), QString(), true, // isGcsMode is bool
                                        bucketName, accountId);
-        updateLog(QString("Schedule applied for GCS Backup: %1 to bucket '%2' (Account: %3) at %4")
-                      .arg(sourcePath, bucketName, accountId, backupTime.toString("HH:mm")));
+        updateLog(QString("Schedule applied for GCS Backup: %1 to bucket '%2' (Account: %3) with %4 times")
+                      .arg(sourcePath, bucketName, accountId)
+                      .arg(times.size()));
     } else {
         QMessageBox::critical(this, tr("Internal Error"), tr("Unknown backup mode selected."));
         updateLog("Error: Apply schedule failed. Unknown backup mode.");
@@ -937,10 +971,15 @@ void MainWindow::onTaskChanged() {
         destinationDirEdit_->setText(scheduler_->destinationPath());
     }
     
-    if (scheduler_->scheduledTime().isValid()) {
-        backupTimeEdit_->setTime(scheduler_->scheduledTime());
+    timeListWidget_->clear();
+    QList<QTime> stimes = scheduler_->scheduledTimes();
+    if (!stimes.isEmpty()) {
+        for (const QTime& t : stimes) {
+            timeListWidget_->addItem(t.toString("HH:mm"));
+        }
+        backupTimeEdit_->setTime(stimes.first());
     } else {
-        backupTimeEdit_->setTime(QTime(23, 0)); 
+        backupTimeEdit_->setTime(QTime(23, 0));
     }
     onBackupModeChanged(backupModeComboBox_->currentIndex());
     updateLog("Task details updated in UI from Scheduler state.");

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -29,6 +29,9 @@
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QHeaderView>
+#include <QDockWidget>
+#include <QMenu>
+#include <QMenuBar>
 #include "CustomTableWidgetItems.h" // For custom sorting items
 
 
@@ -70,6 +73,7 @@ MainWindow::MainWindow(QWidget *parent)
       deleteButton_(nullptr),
       currentPathLabel_(nullptr),
       currentRemotePath_("/"), // Initialize currentRemotePath_
+      fileViewerDockWidget_(nullptr),
       // Core components
       scheduler_(nullptr),
       localTarget_(nullptr),
@@ -120,6 +124,9 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 
 void MainWindow::setupUI() {
     setWindowTitle(tr("BackyFull - Backup Configuration"));
+
+    // Menu bar
+    QMenu *viewMenu = menuBar()->addMenu(tr("&View"));
 
     QWidget *centralWidget = new QWidget(this);
     setCentralWidget(centralWidget);
@@ -232,8 +239,8 @@ void MainWindow::setupUI() {
     mainLayout->addWidget(logDisplay_);
     mainLayout->setStretchFactor(logDisplay_, 1);
 
-    // File Viewer GroupBox
-    fileViewerGroupBox_ = new QGroupBox(tr("Remote File Viewer"), centralWidget); // Parented to centralWidget
+    // File Viewer GroupBox within a DockWidget
+    fileViewerGroupBox_ = new QGroupBox(tr("Remote File Viewer"));
     QVBoxLayout *fileViewerLayout = new QVBoxLayout(); // No parent here, will be set on the group box
 
     currentPathLabel_ = new QLabel(tr("Path: /"), fileViewerGroupBox_); // Parented
@@ -262,8 +269,12 @@ void MainWindow::setupUI() {
     fileViewerLayout->addWidget(fileTableWidget_);
     fileViewerLayout->addLayout(buttonLayout);
     fileViewerGroupBox_->setLayout(fileViewerLayout);
-    mainLayout->addWidget(fileViewerGroupBox_);
-    fileViewerGroupBox_->setVisible(false); // Initially hidden
+
+    fileViewerDockWidget_ = new QDockWidget(tr("Remote File Viewer"), this);
+    fileViewerDockWidget_->setWidget(fileViewerGroupBox_);
+    addDockWidget(Qt::RightDockWidgetArea, fileViewerDockWidget_);
+    fileViewerDockWidget_->hide();
+    viewMenu->addAction(fileViewerDockWidget_->toggleViewAction());
 
     // Connect file viewer signals
     connect(refreshButton_, &QPushButton::clicked, this, &MainWindow::onFileViewerRefreshClicked);
@@ -1032,8 +1043,8 @@ void MainWindow::onBackupModeChanged(int index) {
 
     // Show/hide file viewer group box (only for remote modes)
     bool remoteModeSelected = (sftpSelected || gcsSelected);
-    if (fileViewerGroupBox_) {
-        fileViewerGroupBox_->setVisible(remoteModeSelected);
+    if (fileViewerDockWidget_) {
+        fileViewerDockWidget_->setVisible(remoteModeSelected);
     }
 
     // IMPORTANT: Automatic connection and browsing logic has been removed.

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -13,6 +13,7 @@
 #include <QFileDialog>
 #include <QComboBox>
 #include <QGroupBox>
+#include <QDockWidget>
 #include <QCheckBox>
 #include <QLabel> // Added for gcsAuthStatusLabel_
 // Forward declarations for Qt UI elements related to File Viewer
@@ -109,6 +110,7 @@ private:
 
     // File Viewer UI Elements
     QGroupBox *fileViewerGroupBox_ = nullptr;
+    QDockWidget *fileViewerDockWidget_ = nullptr;
     QTableWidget *fileTableWidget_ = nullptr;
     QPushButton *refreshButton_ = nullptr;
     QPushButton *downloadButton_ = nullptr;

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -9,6 +9,7 @@
 #include <QPushButton>
 #include <QTextEdit>
 #include <QTimeEdit>
+#include <QListWidget>
 #include <QFileDialog>
 #include <QComboBox>
 #include <QGroupBox>
@@ -60,6 +61,8 @@ private slots:
     void onFileViewerDownloadClicked();
     void onFileViewerDeleteClicked();
     void onFileTableItemDoubleClicked(QTableWidgetItem *item);
+    void onAddBackupTimeClicked();
+    void onRemoveBackupTimeClicked();
 
 private:
     void setupUI();
@@ -72,6 +75,9 @@ private:
     QLineEdit *destinationDirEdit_;
     QPushButton *destinationDirButton_;
     QTimeEdit *backupTimeEdit_;
+    QPushButton *addTimeButton_;
+    QListWidget *timeListWidget_;
+    QPushButton *removeTimeButton_;
     QPushButton *applyScheduleButton_;
     QPushButton *runBackupButton_;
     QTextEdit *logDisplay_;

--- a/backy_x/tests/test_scheduler.cpp
+++ b/backy_x/tests/test_scheduler.cpp
@@ -83,7 +83,8 @@ TEST_F(SchedulerTest, InitialState) {
     // - Disabled
     EXPECT_EQ(scheduler_->sourcePath(), QString(""));
     EXPECT_EQ(scheduler_->destinationPath(), QString(""));
-    EXPECT_EQ(scheduler_->scheduledTime(), QTime(23, 0)); // As per Scheduler::loadTask default
+    ASSERT_EQ(scheduler_->scheduledTimes().size(), 1);
+    EXPECT_EQ(scheduler_->scheduledTimes().first(), QTime(23, 0));
     EXPECT_FALSE(scheduler_->isEnabled());
 }
 
@@ -95,11 +96,12 @@ TEST_F(SchedulerTest, SetAndGetTaskProperties) {
 
     QSignalSpy taskChangedSpy(scheduler_, &Scheduler::taskChanged);
 
-    scheduler_->setDailyBackupTask(src, dst, time, enabled, false, QString(), 0, QString(), QString());
+    scheduler_->setDailyBackupTask(src, dst, QList<QTime>{time}, enabled, false, QString(), 0, QString(), QString());
 
     EXPECT_EQ(scheduler_->sourcePath(), src);
     EXPECT_EQ(scheduler_->destinationPath(), dst);
-    EXPECT_EQ(scheduler_->scheduledTime(), time);
+    ASSERT_EQ(scheduler_->scheduledTimes().size(), 1);
+    EXPECT_EQ(scheduler_->scheduledTimes().first(), time);
     EXPECT_EQ(scheduler_->isEnabled(), enabled);
     ASSERT_GE(taskChangedSpy.count(), 1); // taskChanged should be emitted at least once
                                          // (could be twice if loadTask also emits and changes state)
@@ -121,7 +123,7 @@ TEST_F(SchedulerTest, SaveAndLoadTask) {
     QTime time(14, 45);
     bool enabled = true;
 
-    scheduler_->setDailyBackupTask(src, dst, time, enabled, false, QString(), 0, QString(), QString());
+    scheduler_->setDailyBackupTask(src, dst, QList<QTime>{time}, enabled, false, QString(), 0, QString(), QString());
     // Task is saved by setDailyBackupTask.
 
     // Create a new Scheduler instance using the same settings file
@@ -130,7 +132,8 @@ TEST_F(SchedulerTest, SaveAndLoadTask) {
 
     EXPECT_EQ(scheduler2.sourcePath(), src);
     EXPECT_EQ(scheduler2.destinationPath(), dst);
-    EXPECT_EQ(scheduler2.scheduledTime(), time);
+    ASSERT_EQ(scheduler2.scheduledTimes().size(), 1);
+    EXPECT_EQ(scheduler2.scheduledTimes().first(), time);
     EXPECT_EQ(scheduler2.isEnabled(), enabled);
 }
 
@@ -139,10 +142,10 @@ TEST_F(SchedulerTest, DisableTask) {
     QString dst = "/path/dst";
     QTime time(12, 00);
 
-    scheduler_->setDailyBackupTask(src, dst, time, true, false, QString(), 0, QString(), QString()); // Enable first
+    scheduler_->setDailyBackupTask(src, dst, QList<QTime>{time}, true, false, QString(), 0, QString(), QString()); // Enable first
     ASSERT_TRUE(scheduler_->isEnabled());
 
-    scheduler_->setDailyBackupTask(src, dst, time, false, false, QString(), 0, QString(), QString()); // Then disable
+    scheduler_->setDailyBackupTask(src, dst, QList<QTime>{time}, false, false, QString(), 0, QString(), QString()); // Then disable
     EXPECT_FALSE(scheduler_->isEnabled());
 
     // Verify persistence of disabled state
@@ -153,7 +156,7 @@ TEST_F(SchedulerTest, DisableTask) {
 
 TEST_F(SchedulerTest, HandlesEmptyPathsOnSet) {
     // Setting empty paths should be stored as such
-    scheduler_->setDailyBackupTask("", "", QTime(1,1), true, false, QString(), 0, QString(), QString());
+    scheduler_->setDailyBackupTask("", "", QList<QTime>{QTime(1,1)}, true, false, QString(), 0, QString(), QString());
     EXPECT_EQ(scheduler_->sourcePath(), QString(""));
     EXPECT_EQ(scheduler_->destinationPath(), QString(""));
 


### PR DESCRIPTION
## Summary
- allow configuring multiple backup times in Scheduler
- adapt MainWindow UI with list of times and Add/Remove buttons
- update tests for new Scheduler API

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure` *(fails: LocalTargetTest.CopySingleFileToRoot, LocalTargetTest.CopyFileToSubDirectory, SftpTargetTest.BeginSessionInvalidHost)*

------
https://chatgpt.com/codex/tasks/task_e_683fe0e2ae5083218486e68cf3994ee0