### PR TITLE
Add weekday selection for scheduled backups

### DIFF
--- a/backy_x/include/core/Scheduler.h
+++ b/backy_x/include/core/Scheduler.h
@@ -1,15 +1,22 @@
 #ifndef SCHEDULER_H
 #define SCHEDULER_H
 
-#include <QObject>
-#include <QTime>
-#include <QString> // For source/destination paths
-#include <QTimer>
-#include <QSettings> // For persistence
 #include <QList>
+#include <QObject>
+#include <QSet>
+#include <QSettings> // For persistence
+#include <QString>   // For source/destination paths
+#include <QTime>
+#include <QTimer>
+#include <Qt>
 
-// Forward declaration if BackupTask struct becomes complex, for now just basic info
-// struct BackupTask {
+struct ScheduleEntry {
+  QTime time;
+  QSet<Qt::DayOfWeek> days; // empty => all days
+};
+
+// Forward declaration if BackupTask struct becomes complex, for now just basic
+// info struct BackupTask {
 //     QString id; // Might not be needed for M1 with a single task
 //     QString sourcePath;
 //     QString destinationPath;
@@ -18,96 +25,107 @@
 // };
 
 class Scheduler : public QObject {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    explicit Scheduler(const QString& settingsFilePath = QString(), QObject *parent = nullptr);
-    ~Scheduler() override;
+  explicit Scheduler(const QString &settingsFilePath = QString(),
+                     QObject *parent = nullptr);
+  ~Scheduler() override;
 
-    // Configures the daily backup task
-    // Configures the daily backup task
-    void setDailyBackupTask(const QString& sourcePath,
-                            const QString& destinationPathOrIdentifier, // For local, it's path. For SFTP, it might be a descriptive string or empty.
-                            const QList<QTime>& scheduledTimes,
-                            bool enabled,
-                            bool isSftpMode,
-                            const QString& sftpHost = QString(),
-                            int sftpPort = 22,
-                            const QString& sftpUsername = QString(),
-                            const QString& sftpRemotePath = QString(),
-                            bool isGcsMode = false, // New GCS parameter
-                            const QString& gcsBucketName = QString(), // New GCS parameter
-                            const QString& gcsObjectPrefix = QString()); // New GCS parameter (renamed from m_gcsPrefix)
+  // Configures the daily backup task
+  // Configures the daily backup task
+  void setDailyBackupTask(
+      const QString &sourcePath,
+      const QString
+          &destinationPathOrIdentifier, // For local, it's path. For SFTP, it
+                                        // might be a descriptive string or
+                                        // empty.
+      const QList<ScheduleEntry> &scheduleEntries, bool enabled,
+      bool isSftpMode, const QString &sftpHost = QString(), int sftpPort = 22,
+      const QString &sftpUsername = QString(),
+      const QString &sftpRemotePath = QString(),
+      bool isGcsMode = false,                   // New GCS parameter
+      const QString &gcsBucketName = QString(), // New GCS parameter
+      const QString &gcsObjectPrefix =
+          QString()); // New GCS parameter (renamed from m_gcsPrefix)
 
-    // Loads task from QSettings
-    void loadTask();
-    
-    QString sourcePath() const;
-    QString destinationPath() const; // For local mode, or descriptive identifier for SFTP
-    QList<QTime> scheduledTimes() const;
-    bool isEnabled() const;
-    bool isSftpMode() const; // Getter for SFTP mode
+  // Loads task from QSettings
+  void loadTask();
 
-    // Getters for SFTP configuration
-    QString sftpHost() const;
-    int sftpPort() const;
-    QString sftpUsername() const;
-    QString sftpRemotePath() const;
+  QString sourcePath() const;
+  QString
+  destinationPath() const; // For local mode, or descriptive identifier for SFTP
+  QList<QTime> scheduledTimes() const; // legacy helper
+  QList<ScheduleEntry> scheduleEntries() const { return m_scheduleEntries; }
+  bool isEnabled() const;
+  bool isSftpMode() const; // Getter for SFTP mode
 
-    // Getters for GCS configuration
-    bool isGcsMode() const;
-    QString gcsBucketName() const;
-    QString gcsObjectPrefix() const;
-    QString gcsAccountIdentifier() const;
+  // Getters for SFTP configuration
+  QString sftpHost() const;
+  int sftpPort() const;
+  QString sftpUsername() const;
+  QString sftpRemotePath() const;
+
+  // Getters for GCS configuration
+  bool isGcsMode() const;
+  QString gcsBucketName() const;
+  QString gcsObjectPrefix() const;
+  QString gcsAccountIdentifier() const;
 
 signals:
-    // Emitted when a scheduled backup is due
-    // The slot connected to this in MainWindow will use Scheduler's getters to fetch full config
-    void backupTaskTriggered(const QString& sourcePath, const QString& destinationOrIdentifier);
-    // Emitted when task details change, so UI can update
-    void taskChanged(); 
+  // Emitted when a scheduled backup is due
+  // The slot connected to this in MainWindow will use Scheduler's getters to
+  // fetch full config
+  void backupTaskTriggered(const QString &sourcePath,
+                           const QString &destinationOrIdentifier);
+  // Emitted when task details change, so UI can update
+  void taskChanged();
 
 private slots:
-    void checkScheduledTime(); // Slot for the QTimer to call
+  void checkScheduledTime(); // Slot for the QTimer to call
 
 private:
-    void saveTask(); // Saves current task to QSettings
-    void scheduleNextCheck(); // Helper to arm the timer for the next day or initial check
+  void saveTask();          // Saves current task to QSettings
+  void scheduleNextCheck(); // Helper to arm the timer for the next day or
+                            // initial check
 
-    QString m_currentSourcePath;
-    QString m_currentDestinationPath; // For local, this is the path. For SFTP, this might be a placeholder or unused if SFTP details are separate.
-    QList<QTime> m_scheduledTimes;
-    bool m_taskEnabled;
-    
-    // SFTP specific settings
-    bool m_isSftpMode;
-    QString m_sftpHost;
-    int m_sftpPort;
-    QString m_sftpUsername;
-    QString m_sftpRemotePath;
+  QString m_currentSourcePath;
+  QString m_currentDestinationPath; // For local, this is the path. For SFTP,
+                                    // this might be a placeholder or unused if
+                                    // SFTP details are separate.
+  QList<ScheduleEntry> m_scheduleEntries;
+  QList<QTime> m_scheduledTimes; // legacy support
+  bool m_taskEnabled;
 
-    // GCS specific settings
-    bool m_isGcsMode;
-    QString m_gcsBucketName;
-    QString m_gcsObjectPrefix; // Renamed from m_gcsPrefix
+  // SFTP specific settings
+  bool m_isSftpMode;
+  QString m_sftpHost;
+  int m_sftpPort;
+  QString m_sftpUsername;
+  QString m_sftpRemotePath;
 
-    QTimer* m_dailyTimer; // Timer to check if backup is due
-    QSettings* m_settings; // For persisting task details
+  // GCS specific settings
+  bool m_isGcsMode;
+  QString m_gcsBucketName;
+  QString m_gcsObjectPrefix; // Renamed from m_gcsPrefix
 
-    // QSettings keys
-    const QString SETTINGS_GROUP = "Scheduler";
-    const QString KEY_SOURCE_PATH = "sourcePath";
-    const QString KEY_DEST_PATH = "destinationPath"; // Or "destinationIdentifier"
-    const QString KEY_SCHEDULED_TIMES = "scheduledTimes";
-    const QString KEY_TASK_ENABLED = "taskEnabled";
-    const QString KEY_IS_SFTP_MODE = "isSftpMode";
-    const QString KEY_SFTP_HOST = "sftpHost";
-    const QString KEY_SFTP_PORT = "sftpPort";
-    const QString KEY_SFTP_USERNAME = "sftpUsername";
-    const QString KEY_SFTP_REMOTE_PATH = "sftpRemotePath";
-    const QString KEY_IS_GCS_MODE = "isGcsMode";
-    const QString KEY_GCS_BUCKET_NAME = "gcsBucketName";
-    const QString KEY_GCS_OBJECT_PREFIX = "gcsObjectPrefix";
+  QTimer *m_dailyTimer;  // Timer to check if backup is due
+  QSettings *m_settings; // For persisting task details
+
+  // QSettings keys
+  const QString SETTINGS_GROUP = "Scheduler";
+  const QString KEY_SOURCE_PATH = "sourcePath";
+  const QString KEY_DEST_PATH = "destinationPath"; // Or "destinationIdentifier"
+  const QString KEY_SCHEDULED_TIMES = "scheduledTimes";
+  const QString KEY_TASK_ENABLED = "taskEnabled";
+  const QString KEY_IS_SFTP_MODE = "isSftpMode";
+  const QString KEY_SFTP_HOST = "sftpHost";
+  const QString KEY_SFTP_PORT = "sftpPort";
+  const QString KEY_SFTP_USERNAME = "sftpUsername";
+  const QString KEY_SFTP_REMOTE_PATH = "sftpRemotePath";
+  const QString KEY_IS_GCS_MODE = "isGcsMode";
+  const QString KEY_GCS_BUCKET_NAME = "gcsBucketName";
+  const QString KEY_GCS_OBJECT_PREFIX = "gcsObjectPrefix";
 };
 
 #endif // SCHEDULER_H

--- a/backy_x/src/core/Scheduler.cpp
+++ b/backy_x/src/core/Scheduler.cpp
@@ -1,332 +1,392 @@
 #include "core/Scheduler.h"
-#include <QDebug>
 #include <QCoreApplication>
 #include <QDateTime>
+#include <QDebug>
 
-Scheduler::Scheduler(const QString& settingsFilePath, QObject *parent)
-    : QObject(parent),
-      m_taskEnabled(false),
-      m_isSftpMode(false),
-      m_sftpPort(22),
-      m_isGcsMode(false),
-      m_dailyTimer(new QTimer(this)),
-      m_settings(nullptr)
-{
-    if (settingsFilePath.isEmpty()) {
-        if (QCoreApplication::organizationName().isEmpty()) {
-            QCoreApplication::setOrganizationName("BackyFullOrgTestDefault");
-        }
-        if (QCoreApplication::applicationName().isEmpty()) {
-            QCoreApplication::setApplicationName("BackyFullTestDefault");
-        }
-        m_settings = new QSettings(QSettings::IniFormat, QSettings::UserScope,
-                                   QCoreApplication::organizationName(),
-                                   QCoreApplication::applicationName(), this);
-    } else {
-        m_settings = new QSettings(settingsFilePath, QSettings::IniFormat, this);
+Scheduler::Scheduler(const QString &settingsFilePath, QObject *parent)
+    : QObject(parent), m_taskEnabled(false), m_isSftpMode(false),
+      m_sftpPort(22), m_isGcsMode(false), m_dailyTimer(new QTimer(this)),
+      m_settings(nullptr) {
+  if (settingsFilePath.isEmpty()) {
+    if (QCoreApplication::organizationName().isEmpty()) {
+      QCoreApplication::setOrganizationName("BackyFullOrgTestDefault");
     }
-    
-    connect(m_dailyTimer, &QTimer::timeout, this, &Scheduler::checkScheduledTime);
-    loadTask(); 
+    if (QCoreApplication::applicationName().isEmpty()) {
+      QCoreApplication::setApplicationName("BackyFullTestDefault");
+    }
+    m_settings = new QSettings(QSettings::IniFormat, QSettings::UserScope,
+                               QCoreApplication::organizationName(),
+                               QCoreApplication::applicationName(), this);
+  } else {
+    m_settings = new QSettings(settingsFilePath, QSettings::IniFormat, this);
+  }
+
+  connect(m_dailyTimer, &QTimer::timeout, this, &Scheduler::checkScheduledTime);
+  loadTask();
 }
 
 Scheduler::~Scheduler() {
-    // m_dailyTimer and m_settings are children, Qt handles cleanup.
+  // m_dailyTimer and m_settings are children, Qt handles cleanup.
 }
 
-void Scheduler::setDailyBackupTask(const QString& sourcePath,
-                                   const QString& destinationPathOrIdentifier,
-                                   const QList<QTime>& scheduledTimes,
-                                   bool enabled,
-                                   bool isSftpMode,
-                                   const QString& sftpHost,
-                                   int sftpPort,
-                                   const QString& sftpUsername,
-                                   const QString& sftpRemotePath,
-                                   bool isGcsMode,
-                                   const QString& gcsBucketName,
-                                   const QString& gcsObjectPrefix) {
-    m_currentSourcePath = sourcePath;
-    m_currentDestinationPath = destinationPathOrIdentifier; // Store identifier or local path
-    m_scheduledTimes = scheduledTimes;
-    m_taskEnabled = enabled;
-    m_isSftpMode = isSftpMode;
-    m_isGcsMode = isGcsMode;
+void Scheduler::setDailyBackupTask(
+    const QString &sourcePath, const QString &destinationPathOrIdentifier,
+    const QList<ScheduleEntry> &scheduleEntries, bool enabled, bool isSftpMode,
+    const QString &sftpHost, int sftpPort, const QString &sftpUsername,
+    const QString &sftpRemotePath, bool isGcsMode, const QString &gcsBucketName,
+    const QString &gcsObjectPrefix) {
+  m_currentSourcePath = sourcePath;
+  m_currentDestinationPath =
+      destinationPathOrIdentifier; // Store identifier or local path
+  m_scheduleEntries = scheduleEntries;
+  m_scheduledTimes.clear();
+  for (const ScheduleEntry &se : scheduleEntries) {
+    m_scheduledTimes.append(se.time);
+  }
+  m_taskEnabled = enabled;
+  m_isSftpMode = isSftpMode;
+  m_isGcsMode = isGcsMode;
 
-    if (m_isSftpMode) {
-        m_sftpHost = sftpHost;
-        m_sftpPort = sftpPort;
-        m_sftpUsername = sftpUsername;
-        m_sftpRemotePath = sftpRemotePath;
-        // Clear GCS and Local settings if SFTP mode is active
-        m_isGcsMode = false;
-        m_gcsBucketName.clear();
-        m_gcsObjectPrefix.clear();
-        if (!m_isGcsMode) m_currentDestinationPath.clear(); // Clear local path if not GCS (SFTP uses destinationOrIdentifier differently)
+  if (m_isSftpMode) {
+    m_sftpHost = sftpHost;
+    m_sftpPort = sftpPort;
+    m_sftpUsername = sftpUsername;
+    m_sftpRemotePath = sftpRemotePath;
+    // Clear GCS and Local settings if SFTP mode is active
+    m_isGcsMode = false;
+    m_gcsBucketName.clear();
+    m_gcsObjectPrefix.clear();
+    if (!m_isGcsMode)
+      m_currentDestinationPath
+          .clear(); // Clear local path if not GCS (SFTP uses
+                    // destinationOrIdentifier differently)
 
-    } else if (m_isGcsMode) {
-        m_gcsBucketName = gcsBucketName;
-        m_gcsObjectPrefix = gcsObjectPrefix;
-        // Clear SFTP and Local settings if GCS mode is active
-        m_isSftpMode = false;
-        m_sftpHost.clear();
-        m_sftpPort = 22;
-        m_sftpUsername.clear();
-        m_sftpRemotePath.clear();
-        // For GCS, destinationPathOrIdentifier can be used to store bucket name or a GCS specific identifier
-        // Or it can be cleared if gcsBucketName is the sole source of truth for bucket.
-        // Let's assume for now destinationPathOrIdentifier is used for GCS as well.
-        // m_currentDestinationPath = gcsBucketName; // Or some other logic
+  } else if (m_isGcsMode) {
+    m_gcsBucketName = gcsBucketName;
+    m_gcsObjectPrefix = gcsObjectPrefix;
+    // Clear SFTP and Local settings if GCS mode is active
+    m_isSftpMode = false;
+    m_sftpHost.clear();
+    m_sftpPort = 22;
+    m_sftpUsername.clear();
+    m_sftpRemotePath.clear();
+    // For GCS, destinationPathOrIdentifier can be used to store bucket name or
+    // a GCS specific identifier Or it can be cleared if gcsBucketName is the
+    // sole source of truth for bucket. Let's assume for now
+    // destinationPathOrIdentifier is used for GCS as well.
+    // m_currentDestinationPath = gcsBucketName; // Or some other logic
 
-    } else { // Local mode
-        // Clear SFTP and GCS details
-        m_sftpHost.clear();
-        m_sftpPort = 22;
-        m_sftpUsername.clear();
-        m_sftpRemotePath.clear();
-        m_gcsBucketName.clear();
-        m_gcsObjectPrefix.clear();
-    }
+  } else { // Local mode
+    // Clear SFTP and GCS details
+    m_sftpHost.clear();
+    m_sftpPort = 22;
+    m_sftpUsername.clear();
+    m_sftpRemotePath.clear();
+    m_gcsBucketName.clear();
+    m_gcsObjectPrefix.clear();
+  }
 
-    saveTask();
-    scheduleNextCheck();
-    emit taskChanged();
+  saveTask();
+  scheduleNextCheck();
+  emit taskChanged();
 }
 
 void Scheduler::loadTask() {
-    m_settings->beginGroup(SETTINGS_GROUP);
-    m_currentSourcePath = m_settings->value(KEY_SOURCE_PATH, "").toString();
-    m_currentDestinationPath = m_settings->value(KEY_DEST_PATH, "").toString();
-    QStringList timeStrings = m_settings->value(KEY_SCHEDULED_TIMES, QStringList({"23:00"})).toStringList();
-    m_scheduledTimes.clear();
-    for (const QString& ts : timeStrings) {
-        QTime t = QTime::fromString(ts, "HH:mm");
-        if (t.isValid()) m_scheduledTimes.append(t);
+  m_settings->beginGroup(SETTINGS_GROUP);
+  m_currentSourcePath = m_settings->value(KEY_SOURCE_PATH, "").toString();
+  m_currentDestinationPath = m_settings->value(KEY_DEST_PATH, "").toString();
+  QStringList timeStrings =
+      m_settings->value(KEY_SCHEDULED_TIMES, QStringList({"23:00"}))
+          .toStringList();
+  m_scheduleEntries.clear();
+  m_scheduledTimes.clear();
+  for (const QString &ts : timeStrings) {
+    QStringList parts = ts.split('|');
+    QTime t = QTime::fromString(parts.value(0), "HH:mm");
+    if (!t.isValid())
+      continue;
+    ScheduleEntry se;
+    se.time = t;
+    if (parts.size() > 1) {
+      const QStringList dayParts = parts[1].split(',');
+      for (const QString &dStr : dayParts) {
+        bool ok = false;
+        int val = dStr.toInt(&ok);
+        if (ok)
+          se.days.insert(static_cast<Qt::DayOfWeek>(val));
+      }
     }
-    m_taskEnabled = m_settings->value(KEY_TASK_ENABLED, false).toBool();
-    m_isSftpMode = m_settings->value(KEY_IS_SFTP_MODE, false).toBool();
-    m_isGcsMode = m_settings->value(KEY_IS_GCS_MODE, false).toBool();
+    m_scheduleEntries.append(se);
+    m_scheduledTimes.append(t);
+  }
+  m_taskEnabled = m_settings->value(KEY_TASK_ENABLED, false).toBool();
+  m_isSftpMode = m_settings->value(KEY_IS_SFTP_MODE, false).toBool();
+  m_isGcsMode = m_settings->value(KEY_IS_GCS_MODE, false).toBool();
 
-    if (m_isSftpMode) {
-        m_sftpHost = m_settings->value(KEY_SFTP_HOST, "").toString();
-        m_sftpPort = m_settings->value(KEY_SFTP_PORT, 22).toInt();
-        m_sftpUsername = m_settings->value(KEY_SFTP_USERNAME, "").toString();
-        m_sftpRemotePath = m_settings->value(KEY_SFTP_REMOTE_PATH, "").toString();
-    } else if (m_isGcsMode) {
-        m_gcsBucketName = m_settings->value(KEY_GCS_BUCKET_NAME, "").toString();
-        m_gcsObjectPrefix = m_settings->value(KEY_GCS_OBJECT_PREFIX, "").toString();
-    }
-    // No specific 'else' for local mode here, as its primary setting is m_currentDestinationPath
+  if (m_isSftpMode) {
+    m_sftpHost = m_settings->value(KEY_SFTP_HOST, "").toString();
+    m_sftpPort = m_settings->value(KEY_SFTP_PORT, 22).toInt();
+    m_sftpUsername = m_settings->value(KEY_SFTP_USERNAME, "").toString();
+    m_sftpRemotePath = m_settings->value(KEY_SFTP_REMOTE_PATH, "").toString();
+  } else if (m_isGcsMode) {
+    m_gcsBucketName = m_settings->value(KEY_GCS_BUCKET_NAME, "").toString();
+    m_gcsObjectPrefix = m_settings->value(KEY_GCS_OBJECT_PREFIX, "").toString();
+  }
+  // No specific 'else' for local mode here, as its primary setting is
+  // m_currentDestinationPath
 
-    m_settings->endGroup();
+  m_settings->endGroup();
 
-    qDebug() << "Scheduler: Loaded task -"
-             << "Source:" << m_currentSourcePath
-             << "Dest/ID:" << m_currentDestinationPath
-             << "Times:" << m_scheduledTimes
-             << "Enabled:" << m_taskEnabled
-             << "SFTP Mode:" << m_isSftpMode
-             << "GCS Mode:" << m_isGcsMode;
-    if (m_isSftpMode) {
-        qDebug() << "SFTP Details - Host:" << m_sftpHost << "Port:" << m_sftpPort << "User:" << m_sftpUsername << "Path:" << m_sftpRemotePath;
-    }
-    if (m_isGcsMode) {
-        qDebug() << "GCS Details - Bucket:" << m_gcsBucketName << "Prefix:" << m_gcsObjectPrefix;
-    }
+  qDebug() << "Scheduler: Loaded task -"
+           << "Source:" << m_currentSourcePath
+           << "Dest/ID:" << m_currentDestinationPath
+           << "Times:" << m_scheduledTimes << "Enabled:" << m_taskEnabled
+           << "SFTP Mode:" << m_isSftpMode << "GCS Mode:" << m_isGcsMode;
+  if (m_isSftpMode) {
+    qDebug() << "SFTP Details - Host:" << m_sftpHost << "Port:" << m_sftpPort
+             << "User:" << m_sftpUsername << "Path:" << m_sftpRemotePath;
+  }
+  if (m_isGcsMode) {
+    qDebug() << "GCS Details - Bucket:" << m_gcsBucketName
+             << "Prefix:" << m_gcsObjectPrefix;
+  }
 
-    scheduleNextCheck();
-    emit taskChanged();
+  scheduleNextCheck();
+  emit taskChanged();
 }
 
 void Scheduler::saveTask() {
-    m_settings->beginGroup(SETTINGS_GROUP);
-    m_settings->setValue(KEY_SOURCE_PATH, m_currentSourcePath);
-    m_settings->setValue(KEY_DEST_PATH, m_currentDestinationPath);
-    QStringList timeStrings;
-    for (const QTime& t : m_scheduledTimes) {
-        timeStrings << t.toString("HH:mm");
+  m_settings->beginGroup(SETTINGS_GROUP);
+  m_settings->setValue(KEY_SOURCE_PATH, m_currentSourcePath);
+  m_settings->setValue(KEY_DEST_PATH, m_currentDestinationPath);
+  QStringList timeStrings;
+  for (const ScheduleEntry &se : m_scheduleEntries) {
+    QString entry = se.time.toString("HH:mm");
+    if (!se.days.isEmpty()) {
+      QStringList dayNums;
+      for (Qt::DayOfWeek d : se.days) {
+        dayNums << QString::number(int(d));
+      }
+      entry += "|" + dayNums.join(',');
     }
-    m_settings->setValue(KEY_SCHEDULED_TIMES, timeStrings);
-    m_settings->setValue(KEY_TASK_ENABLED, m_taskEnabled);
-    m_settings->setValue(KEY_IS_SFTP_MODE, m_isSftpMode);
-    m_settings->setValue(KEY_IS_GCS_MODE, m_isGcsMode);
+    timeStrings << entry;
+  }
+  m_settings->setValue(KEY_SCHEDULED_TIMES, timeStrings);
+  m_settings->setValue(KEY_TASK_ENABLED, m_taskEnabled);
+  m_settings->setValue(KEY_IS_SFTP_MODE, m_isSftpMode);
+  m_settings->setValue(KEY_IS_GCS_MODE, m_isGcsMode);
 
-    if (m_isSftpMode) {
-        m_settings->setValue(KEY_SFTP_HOST, m_sftpHost);
-        m_settings->setValue(KEY_SFTP_PORT, m_sftpPort);
-        m_settings->setValue(KEY_SFTP_USERNAME, m_sftpUsername);
-        m_settings->setValue(KEY_SFTP_REMOTE_PATH, m_sftpRemotePath);
-        // Remove GCS and Local keys
-        m_settings->remove(KEY_IS_GCS_MODE);
-        m_settings->remove(KEY_GCS_BUCKET_NAME);
-        m_settings->remove(KEY_GCS_OBJECT_PREFIX);
-        // KEY_DEST_PATH is used by SFTP as an identifier, so don't remove it based on SFTP mode alone.
-        // However, if it's truly SFTP, local destination path might be irrelevant.
-        // For now, let's assume setDailyBackupTask correctly sets m_currentDestinationPath for SFTP.
+  if (m_isSftpMode) {
+    m_settings->setValue(KEY_SFTP_HOST, m_sftpHost);
+    m_settings->setValue(KEY_SFTP_PORT, m_sftpPort);
+    m_settings->setValue(KEY_SFTP_USERNAME, m_sftpUsername);
+    m_settings->setValue(KEY_SFTP_REMOTE_PATH, m_sftpRemotePath);
+    // Remove GCS and Local keys
+    m_settings->remove(KEY_IS_GCS_MODE);
+    m_settings->remove(KEY_GCS_BUCKET_NAME);
+    m_settings->remove(KEY_GCS_OBJECT_PREFIX);
+    // KEY_DEST_PATH is used by SFTP as an identifier, so don't remove it based
+    // on SFTP mode alone. However, if it's truly SFTP, local destination path
+    // might be irrelevant. For now, let's assume setDailyBackupTask correctly
+    // sets m_currentDestinationPath for SFTP.
 
-    } else if (m_isGcsMode) {
-        m_settings->setValue(KEY_GCS_BUCKET_NAME, m_gcsBucketName);
-        m_settings->setValue(KEY_GCS_OBJECT_PREFIX, m_gcsObjectPrefix);
-        // Remove SFTP and Local keys (if m_currentDestinationPath is not used for GCS identifier)
-        m_settings->remove(KEY_SFTP_HOST);
-        m_settings->remove(KEY_SFTP_PORT);
-        m_settings->remove(KEY_SFTP_USERNAME);
-        m_settings->remove(KEY_SFTP_REMOTE_PATH);
-        // If m_currentDestinationPath is purely for local mode, remove it.
-        // If it's also an identifier for GCS, this logic needs refinement.
-        // For now, assuming KEY_DEST_PATH might be cleared by setDailyBackupTask if GCS doesn't use it.
-        // Based on current setDailyBackupTask, it's not cleared for GCS, so we don't remove KEY_DEST_PATH here.
+  } else if (m_isGcsMode) {
+    m_settings->setValue(KEY_GCS_BUCKET_NAME, m_gcsBucketName);
+    m_settings->setValue(KEY_GCS_OBJECT_PREFIX, m_gcsObjectPrefix);
+    // Remove SFTP and Local keys (if m_currentDestinationPath is not used for
+    // GCS identifier)
+    m_settings->remove(KEY_SFTP_HOST);
+    m_settings->remove(KEY_SFTP_PORT);
+    m_settings->remove(KEY_SFTP_USERNAME);
+    m_settings->remove(KEY_SFTP_REMOTE_PATH);
+    // If m_currentDestinationPath is purely for local mode, remove it.
+    // If it's also an identifier for GCS, this logic needs refinement.
+    // For now, assuming KEY_DEST_PATH might be cleared by setDailyBackupTask if
+    // GCS doesn't use it. Based on current setDailyBackupTask, it's not cleared
+    // for GCS, so we don't remove KEY_DEST_PATH here.
 
-    } else { // Local mode
-        // Remove SFTP and GCS keys
-        m_settings->remove(KEY_SFTP_HOST);
-        m_settings->remove(KEY_SFTP_PORT);
-        m_settings->remove(KEY_SFTP_USERNAME);
-        m_settings->remove(KEY_SFTP_REMOTE_PATH);
-        m_settings->remove(KEY_IS_GCS_MODE);
-        m_settings->remove(KEY_GCS_BUCKET_NAME);
-        m_settings->remove(KEY_GCS_OBJECT_PREFIX);
-        // KEY_DEST_PATH is for local mode here.
-    }
-    m_settings->endGroup();
-    m_settings->sync(); 
+  } else { // Local mode
+    // Remove SFTP and GCS keys
+    m_settings->remove(KEY_SFTP_HOST);
+    m_settings->remove(KEY_SFTP_PORT);
+    m_settings->remove(KEY_SFTP_USERNAME);
+    m_settings->remove(KEY_SFTP_REMOTE_PATH);
+    m_settings->remove(KEY_IS_GCS_MODE);
+    m_settings->remove(KEY_GCS_BUCKET_NAME);
+    m_settings->remove(KEY_GCS_OBJECT_PREFIX);
+    // KEY_DEST_PATH is for local mode here.
+  }
+  m_settings->endGroup();
+  m_settings->sync();
 
-    qDebug() << "Scheduler: Saved task -"
-             << "Source:" << m_currentSourcePath
-             << "Dest/ID:" << m_currentDestinationPath
-             << "Times:" << m_scheduledTimes
-             << "Enabled:" << m_taskEnabled
-             << "SFTP Mode:" << m_isSftpMode
-             << "GCS Mode:" << m_isGcsMode;
-    if (m_isSftpMode) {
-        qDebug() << "SFTP Details - Host:" << m_sftpHost << "Port:" << m_sftpPort << "User:" << m_sftpUsername << "Path:" << m_sftpRemotePath;
-    }
-    if (m_isGcsMode) {
-        qDebug() << "GCS Details - Bucket:" << m_gcsBucketName << "Prefix:" << m_gcsObjectPrefix;
-    }
+  qDebug() << "Scheduler: Saved task -"
+           << "Source:" << m_currentSourcePath
+           << "Dest/ID:" << m_currentDestinationPath
+           << "Times:" << m_scheduledTimes << "Enabled:" << m_taskEnabled
+           << "SFTP Mode:" << m_isSftpMode << "GCS Mode:" << m_isGcsMode;
+  if (m_isSftpMode) {
+    qDebug() << "SFTP Details - Host:" << m_sftpHost << "Port:" << m_sftpPort
+             << "User:" << m_sftpUsername << "Path:" << m_sftpRemotePath;
+  }
+  if (m_isGcsMode) {
+    qDebug() << "GCS Details - Bucket:" << m_gcsBucketName
+             << "Prefix:" << m_gcsObjectPrefix;
+  }
 }
 
 void Scheduler::scheduleNextCheck() {
-    m_dailyTimer->stop();
-    bool sftpConfigOk = !m_isSftpMode || (!m_sftpHost.isEmpty() && !m_sftpUsername.isEmpty() && !m_sftpRemotePath.isEmpty());
-    bool gcsConfigOk = !m_isGcsMode || !m_gcsBucketName.isEmpty(); // Object prefix can be empty
-    bool localConfigOk = (!m_isSftpMode && !m_isGcsMode) ? !m_currentDestinationPath.isEmpty() : true; // Only check if local mode
+  m_dailyTimer->stop();
+  bool sftpConfigOk =
+      !m_isSftpMode || (!m_sftpHost.isEmpty() && !m_sftpUsername.isEmpty() &&
+                        !m_sftpRemotePath.isEmpty());
+  bool gcsConfigOk =
+      !m_isGcsMode || !m_gcsBucketName.isEmpty(); // Object prefix can be empty
+  bool localConfigOk = (!m_isSftpMode && !m_isGcsMode)
+                           ? !m_currentDestinationPath.isEmpty()
+                           : true; // Only check if local mode
 
-    if (!m_taskEnabled || m_scheduledTimes.isEmpty() || m_currentSourcePath.isEmpty() || !sftpConfigOk || !gcsConfigOk || !localConfigOk) {
-        qDebug() << "Scheduler: Task disabled or not fully configured for the current mode, not scheduling.";
-        if (!m_taskEnabled) qDebug() << "Reason: Task not enabled.";
-        if (m_scheduledTimes.isEmpty()) qDebug() << "Reason: No scheduled times.";
-        if (m_currentSourcePath.isEmpty()) qDebug() << "Reason: Source path empty.";
-        if (m_isSftpMode && !sftpConfigOk) qDebug() << "Reason: SFTP mode active but not fully configured.";
-        if (m_isGcsMode && !gcsConfigOk) qDebug() << "Reason: GCS mode active but bucket name empty.";
-        if (!m_isSftpMode && !m_isGcsMode && !localConfigOk) qDebug() << "Reason: Local mode active but destination path empty.";
-        return;
+  if (!m_taskEnabled || m_scheduleEntries.isEmpty() ||
+      m_currentSourcePath.isEmpty() || !sftpConfigOk || !gcsConfigOk ||
+      !localConfigOk) {
+    qDebug() << "Scheduler: Task disabled or not fully configured for the "
+                "current mode, not scheduling.";
+    if (!m_taskEnabled)
+      qDebug() << "Reason: Task not enabled.";
+    if (m_scheduledTimes.isEmpty())
+      qDebug() << "Reason: No scheduled times.";
+    if (m_currentSourcePath.isEmpty())
+      qDebug() << "Reason: Source path empty.";
+    if (m_isSftpMode && !sftpConfigOk)
+      qDebug() << "Reason: SFTP mode active but not fully configured.";
+    if (m_isGcsMode && !gcsConfigOk)
+      qDebug() << "Reason: GCS mode active but bucket name empty.";
+    if (!m_isSftpMode && !m_isGcsMode && !localConfigOk)
+      qDebug() << "Reason: Local mode active but destination path empty.";
+    return;
+  }
+  QDateTime currentDateTime = QDateTime::currentDateTime();
+  QDateTime nextDateTime;
+  bool found = false;
+  for (const ScheduleEntry &se : m_scheduleEntries) {
+    if (!se.time.isValid())
+      continue;
+    for (int offset = 0; offset < 7; ++offset) {
+      QDate date = currentDateTime.date().addDays(offset);
+      Qt::DayOfWeek dw = static_cast<Qt::DayOfWeek>(date.dayOfWeek());
+      if (!se.days.isEmpty() && !se.days.contains(dw))
+        continue;
+      QDateTime candidate(date, se.time);
+      if (candidate <= currentDateTime)
+        continue;
+      if (!found || candidate < nextDateTime) {
+        nextDateTime = candidate;
+        found = true;
+      }
+      break;
     }
-    QDateTime currentDateTime = QDateTime::currentDateTime();
-    QDateTime nextDateTime;
-    bool found = false;
-    for (const QTime& t : m_scheduledTimes) {
-        if (!t.isValid()) continue;
-        QDateTime candidate(currentDateTime.date(), t);
-        if (candidate < currentDateTime)
-            candidate = candidate.addDays(1);
-        if (!found || candidate < nextDateTime) {
-            nextDateTime = candidate;
-            found = true;
-        }
-    }
-    if (!found) return;
+  }
+  if (!found)
+    return;
 
-    qint64 msecsUntilScheduled = currentDateTime.msecsTo(nextDateTime);
-    if (msecsUntilScheduled < 0) msecsUntilScheduled = 0;
+  qint64 msecsUntilScheduled = currentDateTime.msecsTo(nextDateTime);
+  if (msecsUntilScheduled < 0)
+    msecsUntilScheduled = 0;
 
-    m_dailyTimer->setSingleShot(true);
-    m_dailyTimer->start(msecsUntilScheduled);
+  m_dailyTimer->setSingleShot(true);
+  m_dailyTimer->start(msecsUntilScheduled);
 
-    qDebug() << "Scheduler: Next check scheduled for:" << nextDateTime.toString("yyyy-MM-dd HH:mm:ss")
-             << "in" << msecsUntilScheduled / 1000.0 << "seconds.";
+  qDebug() << "Scheduler: Next check scheduled for:"
+           << nextDateTime.toString("yyyy-MM-dd HH:mm:ss") << "in"
+           << msecsUntilScheduled / 1000.0 << "seconds.";
 }
 
 void Scheduler::checkScheduledTime() {
-    bool sftpConfigOk = !m_isSftpMode || (!m_sftpHost.isEmpty() && !m_sftpUsername.isEmpty() && !m_sftpRemotePath.isEmpty());
-    bool gcsConfigOk = !m_isGcsMode || !m_gcsBucketName.isEmpty(); // Object prefix can be empty
-    bool localConfigOk = (!m_isSftpMode && !m_isGcsMode) ? !m_currentDestinationPath.isEmpty() : true;
+  bool sftpConfigOk =
+      !m_isSftpMode || (!m_sftpHost.isEmpty() && !m_sftpUsername.isEmpty() &&
+                        !m_sftpRemotePath.isEmpty());
+  bool gcsConfigOk =
+      !m_isGcsMode || !m_gcsBucketName.isEmpty(); // Object prefix can be empty
+  bool localConfigOk = (!m_isSftpMode && !m_isGcsMode)
+                           ? !m_currentDestinationPath.isEmpty()
+                           : true;
 
-    if (!m_taskEnabled || m_scheduledTimes.isEmpty() || m_currentSourcePath.isEmpty() || !sftpConfigOk || !gcsConfigOk || !localConfigOk) {
-        qDebug() << "Scheduler: Check time called, but task is not active or fully configured for the current mode.";
-        scheduleNextCheck();
-        return;
-    }
-
-    QTime currentTime = QTime::currentTime();
-    qDebug() << "Scheduler: Timer fired! Current time:" << currentTime.toString("HH:mm:ss")
-             << "Times:" << m_scheduledTimes;
-
-    emit backupTaskTriggered(m_currentSourcePath, m_currentDestinationPath); // Renamed variables
-    
+  if (!m_taskEnabled || m_scheduleEntries.isEmpty() ||
+      m_currentSourcePath.isEmpty() || !sftpConfigOk || !gcsConfigOk ||
+      !localConfigOk) {
+    qDebug() << "Scheduler: Check time called, but task is not active or fully "
+                "configured for the current mode.";
     scheduleNextCheck();
+    return;
+  }
+
+  QDateTime now = QDateTime::currentDateTime();
+  bool shouldTrigger = false;
+  for (const ScheduleEntry &se : m_scheduleEntries) {
+    if (!se.time.isValid())
+      continue;
+    if (!se.days.isEmpty() &&
+        !se.days.contains(static_cast<Qt::DayOfWeek>(now.date().dayOfWeek())))
+      continue;
+    QDateTime candidate(now.date(), se.time);
+    if (qAbs(candidate.secsTo(now)) < 60) { // triggered near scheduled time
+      shouldTrigger = true;
+      break;
+    }
+  }
+
+  if (shouldTrigger)
+    emit backupTaskTriggered(m_currentSourcePath, m_currentDestinationPath);
+
+  scheduleNextCheck();
 }
 
 // --- Getter methods ---
 QString Scheduler::sourcePath() const {
-    return m_currentSourcePath; // Renamed variable
+  return m_currentSourcePath; // Renamed variable
 }
 
 QString Scheduler::destinationPath() const {
-    return m_currentDestinationPath; // Renamed variable (this is dest path for local, or identifier for SFTP)
+  return m_currentDestinationPath; // Renamed variable (this is dest path for
+                                   // local, or identifier for SFTP)
 }
 
-QList<QTime> Scheduler::scheduledTimes() const {
-    return m_scheduledTimes;
-}
+QList<QTime> Scheduler::scheduledTimes() const { return m_scheduledTimes; }
 
 bool Scheduler::isEnabled() const {
-    return m_taskEnabled; // Renamed variable
+  return m_taskEnabled; // Renamed variable
 }
 
-bool Scheduler::isSftpMode() const {
-    return m_isSftpMode;
-}
+bool Scheduler::isSftpMode() const { return m_isSftpMode; }
 
-QString Scheduler::sftpHost() const {
-    return m_sftpHost;
-}
+QString Scheduler::sftpHost() const { return m_sftpHost; }
 
-int Scheduler::sftpPort() const {
-    return m_sftpPort;
-}
+int Scheduler::sftpPort() const { return m_sftpPort; }
 
-QString Scheduler::sftpUsername() const {
-    return m_sftpUsername;
-}
+QString Scheduler::sftpUsername() const { return m_sftpUsername; }
 
-QString Scheduler::sftpRemotePath() const {
-    return m_sftpRemotePath;
-}
+QString Scheduler::sftpRemotePath() const { return m_sftpRemotePath; }
 
 // --- GCS Getter methods ---
-bool Scheduler::isGcsMode() const {
-    return m_isGcsMode;
-}
+bool Scheduler::isGcsMode() const { return m_isGcsMode; }
 
-QString Scheduler::gcsBucketName() const {
-    return m_gcsBucketName;
-}
+QString Scheduler::gcsBucketName() const { return m_gcsBucketName; }
 
-QString Scheduler::gcsObjectPrefix() const {
-    return m_gcsObjectPrefix;
-}
+QString Scheduler::gcsObjectPrefix() const { return m_gcsObjectPrefix; }
 
 QString Scheduler::gcsAccountIdentifier() const {
-    return m_gcsObjectPrefix; // m_gcsObjectPrefix stores the GCS account identifier
+  return m_gcsObjectPrefix; // m_gcsObjectPrefix stores the GCS account
+                            // identifier
 }
 
 // Example of how triggerBackupNow could be implemented if needed:
 // void Scheduler::triggerBackupNow() {
-//     if (taskEnabled_ && !currentSourcePath_.isEmpty() && !currentDestinationPath_.isEmpty()) {
-//         qDebug() << "Scheduler: Manual backup trigger for:" << currentSourcePath_;
-//         emit backupTaskTriggered(currentSourcePath_, currentDestinationPath_);
+//     if (taskEnabled_ && !currentSourcePath_.isEmpty() &&
+//     !currentDestinationPath_.isEmpty()) {
+//         qDebug() << "Scheduler: Manual backup trigger for:" <<
+//         currentSourcePath_; emit backupTaskTriggered(currentSourcePath_,
+//         currentDestinationPath_);
 //     } else {
-//         qDebug() << "Scheduler: Manual backup trigger ignored, task not enabled or not configured.";
+//         qDebug() << "Scheduler: Manual backup trigger ignored, task not
+//         enabled or not configured.";
 //     }
 // }

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -18,6 +18,7 @@
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QScreen>
 #include <QMessageBox>
 #include <QSettings>
 #include <QStandardPaths>
@@ -133,6 +134,9 @@ void MainWindow::setupUI() {
 
   QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
   setMinimumSize(800, 600);
+  if (QScreen *scr = QApplication::primaryScreen()) {
+    setMaximumHeight(scr->availableGeometry().height());
+  }
 
   QHBoxLayout *modeLayout = new QHBoxLayout();
   modeLayout->addWidget(new QLabel(tr("Backup Mode:")));
@@ -470,7 +474,7 @@ void MainWindow::onAutoWatchToggled(bool checked) {
       }
     }
   }
-  adjustSize();
+  adjustHeightToScreen();
 }
 
 void MainWindow::onDirectoryChanged(const QString &path) {
@@ -1438,7 +1442,7 @@ void MainWindow::onBackupModeChanged(int index) {
           "Backup mode changed to: %1. UI adjusted. File viewer visible: %2.")
           .arg(currentModeText)
           .arg(remoteModeSelected ? "Yes" : "No"));
-  adjustSize();
+  adjustHeightToScreen();
 }
 
 void MainWindow::loadSettings() {
@@ -2163,4 +2167,14 @@ QString MainWindow::currentDestinationForDisplay() const {
     return QString("gcs://%1").arg(gcsBucketNameLineEdit_->text());
   }
   return destinationDirEdit_->text();
+}
+
+void MainWindow::adjustHeightToScreen() {
+  adjustSize();
+  QScreen *scr = QApplication::primaryScreen();
+  if (!scr)
+    return;
+  int avail = scr->availableGeometry().height() - 40; // small margin
+  if (height() > avail)
+    resize(width(), avail);
 }

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -151,6 +151,21 @@ void MainWindow::setupUI() {
   connect(sourceDirButton_, &QPushButton::clicked, this,
           &MainWindow::selectSourceDirectory);
   sourceLayout->addWidget(sourceDirButton_, 0, 2);
+
+  watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
+  QGridLayout *watchLayout = new QGridLayout(watchGroupBox_);
+  watchEnableCheckBox_ =
+      new QCheckBox(tr("Activer la surveillance automatique de ce dossier"));
+  watchLayout->addWidget(watchEnableCheckBox_, 0, 0, 1, 3);
+  watchLayout->addWidget(new QLabel(tr("Dossier à surveiller:")), 1, 0);
+  watchDirEdit_ = new QLineEdit();
+  watchDirEdit_->setReadOnly(true);
+  watchLayout->addWidget(watchDirEdit_, 1, 1);
+  watchDirButton_ = new QPushButton(tr("Browse..."));
+  watchLayout->addWidget(watchDirButton_, 1, 2);
+  watchStatusLabel_ = new QLabel(tr("Surveillance inactive"));
+  watchLayout->addWidget(watchStatusLabel_, 2, 0, 1, 3);
+  sourceLayout->addWidget(watchGroupBox_, 1, 0, 1, 3);
   mainLayout->addWidget(sourceGroupBox);
 
   m_localDestinationGroupBox =
@@ -261,26 +276,6 @@ void MainWindow::setupUI() {
           &MainWindow::runBackupNow);
   scheduleLayout->addWidget(runBackupButton_, 6, 0, 1, 3);
   mainLayout->addWidget(scheduleGroupBox);
-
-  watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
-  QGridLayout *watchLayout = new QGridLayout(watchGroupBox_);
-  watchEnableCheckBox_ =
-      new QCheckBox(tr("Activer la surveillance automatique de ce dossier"));
-  watchLayout->addWidget(watchEnableCheckBox_, 0, 0, 1, 3);
-  watchLayout->addWidget(new QLabel(tr("Dossier à surveiller:")), 1, 0);
-  watchDirEdit_ = new QLineEdit();
-  watchDirEdit_->setReadOnly(true);
-  watchLayout->addWidget(watchDirEdit_, 1, 1);
-  watchDirButton_ = new QPushButton(tr("Browse..."));
-  watchLayout->addWidget(watchDirButton_, 1, 2);
-  watchStatusLabel_ = new QLabel(tr("Surveillance inactive"));
-  watchLayout->addWidget(watchStatusLabel_, 2, 0, 1, 3);
-  mainLayout->addWidget(watchGroupBox_);
-
-  connect(watchDirButton_, &QPushButton::clicked, this,
-          &MainWindow::selectWatchDirectory);
-  connect(watchEnableCheckBox_, &QCheckBox::toggled, this,
-          &MainWindow::onAutoWatchToggled);
 
   mainLayout->addWidget(new QLabel(tr("Logs:")));
   logDisplay_ = new QTextEdit();
@@ -410,7 +405,14 @@ void MainWindow::onAddBackupTimeClicked() {
 }
 
 void MainWindow::onRemoveBackupTimeClicked() {
-  qDeleteAll(timeListWidget_->selectedItems());
+  const QList<QListWidgetItem *> items = timeListWidget_->selectedItems();
+  for (QListWidgetItem *item : items) {
+    QString data = item->data(Qt::UserRole).toString();
+    if (data.startsWith("WATCH|")) {
+      watchEnableCheckBox_->setChecked(false);
+    }
+    delete item;
+  }
 }
 
 void MainWindow::selectWatchDirectory() {
@@ -438,11 +440,41 @@ void MainWindow::onAutoWatchToggled(bool checked) {
     if (!dir.isEmpty()) {
       dirWatcher_->addPath(dir);
       watchStatusLabel_->setText(tr("Surveillance active"));
+      QString data = QStringLiteral("WATCH|") + dir;
+      QString display = QString::fromUtf8("\xF0\x9F\x93\x82 ") +
+                        tr("Surveillance: %1").arg(dir);
+      bool found = false;
+      for (int i = 0; i < timeListWidget_->count(); ++i) {
+        QListWidgetItem *it = timeListWidget_->item(i);
+        QString d = it->data(Qt::UserRole).toString();
+        if (d.startsWith("WATCH|")) {
+          it->setText(display);
+          it->setData(Qt::UserRole, data);
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        QListWidgetItem *item = new QListWidgetItem(display);
+        QFont f = item->font();
+        f.setItalic(true);
+        item->setFont(f);
+        item->setData(Qt::UserRole, data);
+        timeListWidget_->addItem(item);
+      }
     } else {
       watchStatusLabel_->setText(tr("No directory set"));
     }
   } else {
     watchStatusLabel_->setText(tr("Surveillance inactive"));
+    for (int i = 0; i < timeListWidget_->count(); ++i) {
+      QListWidgetItem *it = timeListWidget_->item(i);
+      QString d = it->data(Qt::UserRole).toString();
+      if (d.startsWith("WATCH|")) {
+        delete timeListWidget_->takeItem(i);
+        break;
+      }
+    }
   }
 }
 
@@ -463,6 +495,8 @@ void MainWindow::applySchedule() {
   QList<ScheduleEntry> entries;
   for (int i = 0; i < timeListWidget_->count(); ++i) {
     QString data = timeListWidget_->item(i)->data(Qt::UserRole).toString();
+    if (data.startsWith("WATCH|"))
+      continue;
     QStringList parts = data.split('|');
     QTime t = QTime::fromString(parts.value(0), "HH:mm");
     if (!t.isValid())
@@ -1324,6 +1358,9 @@ void MainWindow::onTaskChanged() {
     backupTimeEdit_->setTime(entries.first().time);
   } else {
     backupTimeEdit_->setTime(QTime(23, 0));
+  }
+  if (watchEnableCheckBox_->isChecked()) {
+    onAutoWatchToggled(true);
   }
   onBackupModeChanged(backupModeComboBox_->currentIndex());
   updateLog("Task details updated in UI from Scheduler state.");

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -60,8 +60,7 @@ MainWindow::MainWindow(QWidget *parent)
       currentPathLabel_(nullptr),
       currentRemotePath_("/"), // Initialize currentRemotePath_
       fileViewerDockWidget_(nullptr), watchGroupBox_(nullptr),
-      watchEnableCheckBox_(nullptr), watchDirEdit_(nullptr),
-      watchDirButton_(nullptr), watchStatusLabel_(nullptr),
+      watchEnableCheckBox_(nullptr), watchStatusLabel_(nullptr),
       dirWatcher_(nullptr), watchTriggerTimer_(nullptr),
       // Core components
       scheduler_(nullptr), localTarget_(nullptr), sftpTarget_(nullptr),
@@ -157,14 +156,10 @@ void MainWindow::setupUI() {
   watchEnableCheckBox_ =
       new QCheckBox(tr("Activer la surveillance automatique de ce dossier"));
   watchLayout->addWidget(watchEnableCheckBox_, 0, 0, 1, 3);
-  watchLayout->addWidget(new QLabel(tr("Dossier à surveiller:")), 1, 0);
-  watchDirEdit_ = new QLineEdit();
-  watchDirEdit_->setReadOnly(true);
-  watchLayout->addWidget(watchDirEdit_, 1, 1);
-  watchDirButton_ = new QPushButton(tr("Browse..."));
-  watchLayout->addWidget(watchDirButton_, 1, 2);
   watchStatusLabel_ = new QLabel(tr("Surveillance inactive"));
-  watchLayout->addWidget(watchStatusLabel_, 2, 0, 1, 3);
+  watchLayout->addWidget(watchStatusLabel_, 1, 0, 1, 3);
+  connect(watchEnableCheckBox_, &QCheckBox::toggled, this,
+          &MainWindow::onAutoWatchToggled);
   sourceLayout->addWidget(watchGroupBox_, 1, 0, 1, 3);
   mainLayout->addWidget(sourceGroupBox);
 
@@ -352,6 +347,9 @@ void MainWindow::selectSourceDirectory() {
   if (!directory.isEmpty()) {
     sourceDirEdit_->setText(QDir::toNativeSeparators(directory));
     updateLog(QString("Source directory selected: %1").arg(directory));
+    if (watchEnableCheckBox_->isChecked()) {
+      onAutoWatchToggled(true);
+    }
   }
 }
 
@@ -397,6 +395,11 @@ void MainWindow::onAddBackupTimeClicked() {
     display += " (" + dayNames.join(',') + ")";
   else
     display += tr(" (All)");
+  QString srcDisp = shortenPathForDisplay(sourceDirEdit_->text());
+  QString destDisp = shortenPathForDisplay(currentDestinationForDisplay());
+  if (!srcDisp.isEmpty() && !destDisp.isEmpty()) {
+    display += QString(" | %1 \u2192 %2").arg(srcDisp, destDisp);
+  }
   QListWidgetItem *item = new QListWidgetItem(display);
   item->setData(Qt::UserRole, dataString);
   timeListWidget_->addItem(item);
@@ -415,34 +418,21 @@ void MainWindow::onRemoveBackupTimeClicked() {
   }
 }
 
-void MainWindow::selectWatchDirectory() {
-  fileDialog_->setWindowTitle(tr("Select Directory to Watch"));
-  fileDialog_->setFileMode(QFileDialog::Directory);
-  fileDialog_->setOption(QFileDialog::ShowDirsOnly, true);
-  QString initialPath =
-      watchDirEdit_->text().isEmpty()
-          ? QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-          : watchDirEdit_->text();
-  QString directory = fileDialog_->getExistingDirectory(
-      this, tr("Select Directory to Watch"), initialPath);
-  if (!directory.isEmpty()) {
-    watchDirEdit_->setText(QDir::toNativeSeparators(directory));
-    if (watchEnableCheckBox_->isChecked()) {
-      onAutoWatchToggled(true);
-    }
-  }
-}
-
 void MainWindow::onAutoWatchToggled(bool checked) {
   dirWatcher_->removePaths(dirWatcher_->directories());
   if (checked) {
-    QString dir = watchDirEdit_->text();
+    QString dir = sourceDirEdit_->text();
     if (!dir.isEmpty()) {
       dirWatcher_->addPath(dir);
-      watchStatusLabel_->setText(tr("Surveillance active"));
+      watchStatusLabel_->setText(
+          QString::fromUtf8("\xF0\x9F\x93\x82 ") +
+          tr("Dossier surveill\u00e9 : %1")
+              .arg(shortenPathForDisplay(dir)));
       QString data = QStringLiteral("WATCH|") + dir;
-      QString display = QString::fromUtf8("\xF0\x9F\x93\x82 ") +
-                        tr("Surveillance: %1").arg(dir);
+      QString display = QString::fromUtf8("\xF0\x9F\x93\x81 ") +
+                        tr("Surveillance active | %1 \u2192 %2")
+                            .arg(shortenPathForDisplay(dir),
+                                 currentDestinationForDisplay());
       bool found = false;
       for (int i = 0; i < timeListWidget_->count(); ++i) {
         QListWidgetItem *it = timeListWidget_->item(i);
@@ -1351,6 +1341,20 @@ void MainWindow::onTaskChanged() {
       } else {
         display += tr(" (All)");
       }
+      QString srcDisp = shortenPathForDisplay(scheduler_->sourcePath());
+      QString destDisp;
+      if (scheduler_->isSftpMode()) {
+        destDisp = QString("%1:%2")
+                       .arg(scheduler_->sftpHost(), scheduler_->sftpRemotePath());
+      } else if (scheduler_->isGcsMode()) {
+        destDisp = QString("gcs://%1").arg(scheduler_->gcsBucketName());
+      } else {
+        destDisp = scheduler_->destinationPath();
+      }
+      destDisp = shortenPathForDisplay(destDisp);
+      if (!srcDisp.isEmpty() && !destDisp.isEmpty()) {
+        display += QString(" | %1 \u2192 %2").arg(srcDisp, destDisp);
+      }
       QListWidgetItem *item = new QListWidgetItem(display);
       item->setData(Qt::UserRole, data);
       timeListWidget_->addItem(item);
@@ -1451,7 +1455,6 @@ void MainWindow::loadSettings() {
 
   settings.beginGroup("AutoWatch");
   watchEnableCheckBox_->setChecked(settings.value("enabled", false).toBool());
-  watchDirEdit_->setText(settings.value("directory", "").toString());
   settings.endGroup();
 
   if (watchEnableCheckBox_->isChecked()) {
@@ -1513,7 +1516,6 @@ void MainWindow::saveSettings() {
 
   settings.beginGroup("AutoWatch");
   settings.setValue("enabled", watchEnableCheckBox_->isChecked());
-  settings.setValue("directory", watchDirEdit_->text());
   settings.endGroup();
 
   if (backupModeComboBox_->currentText() == tr("SFTP Backup")) {
@@ -2136,4 +2138,24 @@ void MainWindow::onFileTableItemDoubleClicked(QTableWidgetItem *item) {
         QString("Double-clicked file: %1. Triggering download.").arg(itemName));
     onFileViewerDownloadClicked();
   }
+}
+
+QString MainWindow::shortenPathForDisplay(const QString &path) const {
+  QDir home = QDir::home();
+  QString relative = home.relativeFilePath(path);
+  if (!relative.startsWith("..")) {
+    return QString("~/") + relative;
+  }
+  return path;
+}
+
+QString MainWindow::currentDestinationForDisplay() const {
+  QString currentModeText = backupModeComboBox_->currentText();
+  if (currentModeText == tr("SFTP Backup")) {
+    return QString("%1:%2")
+        .arg(sftpHostLineEdit_->text(), sftpRemotePathLineEdit_->text());
+  } else if (currentModeText == tr("Google Cloud Storage")) {
+    return QString("gcs://%1").arg(gcsBucketNameLineEdit_->text());
+  }
+  return destinationDirEdit_->text();
 }

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -43,7 +43,7 @@ MainWindow::MainWindow(QWidget *parent)
       backupTimeEdit_(nullptr), addTimeButton_(nullptr),
       timeListWidget_(nullptr), removeTimeButton_(nullptr),
       applyScheduleButton_(nullptr), runBackupButton_(nullptr),
-      logDisplay_(nullptr), backupModeComboBox_(nullptr),
+      logDisplay_(nullptr), scrollArea_(nullptr), backupModeComboBox_(nullptr),
       m_localDestinationGroupBox(nullptr), sftpSettingsGroupBox_(nullptr),
       sftpHostLineEdit_(nullptr), sftpPortLineEdit_(nullptr),
       sftpUsernameLineEdit_(nullptr), sftpPasswordLineEdit_(nullptr),
@@ -55,11 +55,11 @@ MainWindow::MainWindow(QWidget *parent)
           nullptr), // Initialize new GCS Test Connection button
       gcsAuthStatusLabel_(nullptr), gcsConnectToggleButton_(nullptr),
       // File Viewer UI Elements
-      fileViewerGroupBox_(nullptr), fileTableWidget_(nullptr),
-      refreshButton_(nullptr), downloadButton_(nullptr), deleteButton_(nullptr),
-      currentPathLabel_(nullptr),
+      fileViewerGroupBox_(nullptr), fileViewerDockWidget_(nullptr),
+      fileTableWidget_(nullptr), refreshButton_(nullptr),
+      downloadButton_(nullptr), deleteButton_(nullptr), currentPathLabel_(nullptr),
       currentRemotePath_("/"), // Initialize currentRemotePath_
-      fileViewerDockWidget_(nullptr), watchGroupBox_(nullptr),
+      watchGroupBox_(nullptr),
       watchEnableCheckBox_(nullptr), watchStatusLabel_(nullptr),
       dirWatcher_(nullptr), watchTriggerTimer_(nullptr),
       // Core components
@@ -125,10 +125,14 @@ void MainWindow::setupUI() {
   // Menu bar
   QMenu *viewMenu = menuBar()->addMenu(tr("&View"));
 
-  QWidget *centralWidget = new QWidget(this);
-  setCentralWidget(centralWidget);
+  scrollArea_ = new QScrollArea(this);
+  setCentralWidget(scrollArea_);
+  scrollArea_->setWidgetResizable(true);
+  QWidget *centralWidget = new QWidget(scrollArea_);
+  scrollArea_->setWidget(centralWidget);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
+  setMinimumSize(800, 600);
 
   QHBoxLayout *modeLayout = new QHBoxLayout();
   modeLayout->addWidget(new QLabel(tr("Backup Mode:")));
@@ -466,6 +470,7 @@ void MainWindow::onAutoWatchToggled(bool checked) {
       }
     }
   }
+  adjustSize();
 }
 
 void MainWindow::onDirectoryChanged(const QString &path) {
@@ -1328,7 +1333,6 @@ void MainWindow::onTaskChanged() {
       if (!se.days.isEmpty()) {
         QStringList names;
         QStringList nums;
-        int idx = 1;
         const QStringList dayLabels = {tr("Mon"), tr("Tue"), tr("Wed"),
                                        tr("Thu"), tr("Fri"), tr("Sat"),
                                        tr("Sun")};
@@ -1434,6 +1438,7 @@ void MainWindow::onBackupModeChanged(int index) {
           "Backup mode changed to: %1. UI adjusted. File viewer visible: %2.")
           .arg(currentModeText)
           .arg(remoteModeSelected ? "Yes" : "No"));
+  adjustSize();
 }
 
 void MainWindow::loadSettings() {

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -1,1689 +1,2102 @@
 #include "gui/MainWindow.h"
 #include "core/Scheduler.h"
+#include "targets/GcsTarget.h" // Added for GCS Target
 #include "targets/LocalTarget.h"
 #include "targets/SftpTarget.h"
-#include "targets/GcsTarget.h"      // Added for GCS Target
 #include "util/CredentialManager.h"
 
 #include <QApplication> // Added include
-#include <QVBoxLayout>
-#include <QHBoxLayout>
-#include <QGridLayout>
-#include <QFormLayout>
-#include <QWidget>
-#include <QLabel>
-#include <QFileDialog>
-#include <QMessageBox>
-#include <QTime>
-#include <QDir>
-#include <QFileInfo>
-#include <QDebug>
-#include <QStandardPaths>
-#include <QSettings>
-#include <QCoreApplication>
 #include <QCloseEvent>
+#include <QCoreApplication>
 #include <QDateTime>
+#include <QDebug>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
 #include <QFileSystemWatcher>
+#include <QFormLayout>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QTime>
 #include <QTimer>
+#include <QVBoxLayout>
+#include <QWidget>
 #include <filesystem>
 #include <functional>
 #include <map>
 // Added for File Viewer
-#include <QTableWidget>
-#include <QTableWidgetItem>
-#include <QHeaderView>
+#include "CustomTableWidgetItems.h" // For custom sorting items
 #include <QDockWidget>
+#include <QHeaderView>
 #include <QMenu>
 #include <QMenuBar>
-#include "CustomTableWidgetItems.h" // For custom sorting items
-
+#include <QTableWidget>
+#include <QTableWidgetItem>
 
 MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent),
-      sourceDirEdit_(nullptr),
-      sourceDirButton_(nullptr),
-      destinationDirEdit_(nullptr),
-      destinationDirButton_(nullptr),
-      backupTimeEdit_(nullptr),
-      addTimeButton_(nullptr),
-      timeListWidget_(nullptr),
-      removeTimeButton_(nullptr),
-      applyScheduleButton_(nullptr),
-      runBackupButton_(nullptr),
-      logDisplay_(nullptr),
-      backupModeComboBox_(nullptr),
-      m_localDestinationGroupBox(nullptr),
-      sftpSettingsGroupBox_(nullptr),
-      sftpHostLineEdit_(nullptr),
-      sftpPortLineEdit_(nullptr),
-      sftpUsernameLineEdit_(nullptr),
-      sftpPasswordLineEdit_(nullptr),
-      sftpRemotePathLineEdit_(nullptr),
-      sftpSavePasswordCheckBox_(nullptr),
-      sftpConnectToggleButton_(nullptr),
-      gcsSettingsGroupBox_(nullptr),
-      gcsBucketNameLineEdit_(nullptr),
-      gcsAccountIdentifierLineEdit_(nullptr),
+    : QMainWindow(parent), sourceDirEdit_(nullptr), sourceDirButton_(nullptr),
+      destinationDirEdit_(nullptr), destinationDirButton_(nullptr),
+      backupTimeEdit_(nullptr), addTimeButton_(nullptr),
+      timeListWidget_(nullptr), removeTimeButton_(nullptr),
+      applyScheduleButton_(nullptr), runBackupButton_(nullptr),
+      logDisplay_(nullptr), backupModeComboBox_(nullptr),
+      m_localDestinationGroupBox(nullptr), sftpSettingsGroupBox_(nullptr),
+      sftpHostLineEdit_(nullptr), sftpPortLineEdit_(nullptr),
+      sftpUsernameLineEdit_(nullptr), sftpPasswordLineEdit_(nullptr),
+      sftpRemotePathLineEdit_(nullptr), sftpSavePasswordCheckBox_(nullptr),
+      sftpConnectToggleButton_(nullptr), gcsSettingsGroupBox_(nullptr),
+      gcsBucketNameLineEdit_(nullptr), gcsAccountIdentifierLineEdit_(nullptr),
       gcsConnectButton_(nullptr),
-      gcsTestConnectionButton_(nullptr), // Initialize new GCS Test Connection button
-      gcsAuthStatusLabel_(nullptr),
-      gcsConnectToggleButton_(nullptr),
+      gcsTestConnectionButton_(
+          nullptr), // Initialize new GCS Test Connection button
+      gcsAuthStatusLabel_(nullptr), gcsConnectToggleButton_(nullptr),
       // File Viewer UI Elements
-      fileViewerGroupBox_(nullptr),
-      fileTableWidget_(nullptr),
-      refreshButton_(nullptr),
-      downloadButton_(nullptr),
-      deleteButton_(nullptr),
+      fileViewerGroupBox_(nullptr), fileTableWidget_(nullptr),
+      refreshButton_(nullptr), downloadButton_(nullptr), deleteButton_(nullptr),
       currentPathLabel_(nullptr),
       currentRemotePath_("/"), // Initialize currentRemotePath_
-      fileViewerDockWidget_(nullptr),
-      watchGroupBox_(nullptr),
-      watchEnableCheckBox_(nullptr),
-      watchDirEdit_(nullptr),
-      watchDirButton_(nullptr),
-      watchStatusLabel_(nullptr),
-      dirWatcher_(nullptr),
-      watchTriggerTimer_(nullptr),
+      fileViewerDockWidget_(nullptr), watchGroupBox_(nullptr),
+      watchEnableCheckBox_(nullptr), watchDirEdit_(nullptr),
+      watchDirButton_(nullptr), watchStatusLabel_(nullptr),
+      dirWatcher_(nullptr), watchTriggerTimer_(nullptr),
       // Core components
-      scheduler_(nullptr),
-      localTarget_(nullptr),
-      sftpTarget_(nullptr),
-      gcsTarget_(nullptr),            // Initialize GCS target member
+      scheduler_(nullptr), localTarget_(nullptr), sftpTarget_(nullptr),
+      gcsTarget_(nullptr), // Initialize GCS target member
       m_credentialManager(nullptr),
       // Helper for file dialogs
-      fileDialog_(nullptr)
-{
-    if (QCoreApplication::organizationName().isEmpty()) {
-        QCoreApplication::setOrganizationName("BackyFullOrg");
-    }
-    if (QCoreApplication::applicationName().isEmpty()) {
-        QCoreApplication::setApplicationName("BackyFull");
-    }
-    
-    m_credentialManager = std::unique_ptr<CredentialManager>(createPlatformCredentialManager());
-    scheduler_ = new Scheduler(QString(), this);
+      fileDialog_(nullptr) {
+  if (QCoreApplication::organizationName().isEmpty()) {
+    QCoreApplication::setOrganizationName("BackyFullOrg");
+  }
+  if (QCoreApplication::applicationName().isEmpty()) {
+    QCoreApplication::setApplicationName("BackyFull");
+  }
 
-    dirWatcher_ = new QFileSystemWatcher(this);
-    watchTriggerTimer_ = new QTimer(this);
-    watchTriggerTimer_->setSingleShot(true);
-    connect(dirWatcher_, &QFileSystemWatcher::directoryChanged, this, &MainWindow::onDirectoryChanged);
-    connect(watchTriggerTimer_, &QTimer::timeout, this, &MainWindow::onWatchTimerTimeout);
+  m_credentialManager =
+      std::unique_ptr<CredentialManager>(createPlatformCredentialManager());
+  scheduler_ = new Scheduler(QString(), this);
 
-    setupUI();
-    loadSettings();
+  dirWatcher_ = new QFileSystemWatcher(this);
+  watchTriggerTimer_ = new QTimer(this);
+  watchTriggerTimer_->setSingleShot(true);
+  connect(dirWatcher_, &QFileSystemWatcher::directoryChanged, this,
+          &MainWindow::onDirectoryChanged);
+  connect(watchTriggerTimer_, &QTimer::timeout, this,
+          &MainWindow::onWatchTimerTimeout);
 
-    connect(scheduler_, &Scheduler::backupTaskTriggered, this, &MainWindow::handleScheduledBackup);
-    connect(scheduler_, &Scheduler::taskChanged, this, &MainWindow::onTaskChanged);
+  setupUI();
+  loadSettings();
 
-    if (backupModeComboBox_) {
-        onBackupModeChanged(backupModeComboBox_->currentIndex());
-    }
-    onTaskChanged();
+  connect(scheduler_, &Scheduler::backupTaskTriggered, this,
+          &MainWindow::handleScheduledBackup);
+  connect(scheduler_, &Scheduler::taskChanged, this,
+          &MainWindow::onTaskChanged);
 
-    updateLog("BackyFull application started.");
-    updateLog("Please configure your backup source, destination/SFTP, and schedule.");
+  if (backupModeComboBox_) {
+    onBackupModeChanged(backupModeComboBox_->currentIndex());
+  }
+  onTaskChanged();
+
+  updateLog("BackyFull application started.");
+  updateLog(
+      "Please configure your backup source, destination/SFTP, and schedule.");
 }
 
 MainWindow::~MainWindow() {
-    delete localTarget_; 
-    localTarget_ = nullptr;
-    delete sftpTarget_; 
-    sftpTarget_ = nullptr;
-    delete gcsTarget_;
-    gcsTarget_ = nullptr;
+  delete localTarget_;
+  localTarget_ = nullptr;
+  delete sftpTarget_;
+  sftpTarget_ = nullptr;
+  delete gcsTarget_;
+  gcsTarget_ = nullptr;
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {
-    saveSettings();
-    QMainWindow::closeEvent(event);
+  saveSettings();
+  QMainWindow::closeEvent(event);
 }
 
 void MainWindow::setupUI() {
-    setWindowTitle(tr("BackyFull - Backup Configuration"));
+  setWindowTitle(tr("BackyFull - Backup Configuration"));
 
-    // Menu bar
-    QMenu *viewMenu = menuBar()->addMenu(tr("&View"));
+  // Menu bar
+  QMenu *viewMenu = menuBar()->addMenu(tr("&View"));
 
-    QWidget *centralWidget = new QWidget(this);
-    setCentralWidget(centralWidget);
+  QWidget *centralWidget = new QWidget(this);
+  setCentralWidget(centralWidget);
 
-    QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
-    
-    QHBoxLayout *modeLayout = new QHBoxLayout();
-    modeLayout->addWidget(new QLabel(tr("Backup Mode:")));
-    backupModeComboBox_ = new QComboBox();
-    backupModeComboBox_->addItem(tr("Local Backup"));
-    backupModeComboBox_->addItem(tr("SFTP Backup"));
-    backupModeComboBox_->addItem(tr("Google Cloud Storage"));
-    modeLayout->addWidget(backupModeComboBox_);
-    modeLayout->addStretch();
-    mainLayout->addLayout(modeLayout);
+  QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
 
-    QGroupBox *sourceGroupBox = new QGroupBox(tr("Source Configuration"));
-    QGridLayout *sourceLayout = new QGridLayout(sourceGroupBox);
-    sourceLayout->addWidget(new QLabel(tr("Source Directory:")), 0, 0);
-    sourceDirEdit_ = new QLineEdit();
-    sourceDirEdit_->setReadOnly(true);
-    sourceLayout->addWidget(sourceDirEdit_, 0, 1);
-    sourceDirButton_ = new QPushButton(tr("Browse..."));
-    connect(sourceDirButton_, &QPushButton::clicked, this, &MainWindow::selectSourceDirectory);
-    sourceLayout->addWidget(sourceDirButton_, 0, 2);
-    mainLayout->addWidget(sourceGroupBox);
+  QHBoxLayout *modeLayout = new QHBoxLayout();
+  modeLayout->addWidget(new QLabel(tr("Backup Mode:")));
+  backupModeComboBox_ = new QComboBox();
+  backupModeComboBox_->addItem(tr("Local Backup"));
+  backupModeComboBox_->addItem(tr("SFTP Backup"));
+  backupModeComboBox_->addItem(tr("Google Cloud Storage"));
+  modeLayout->addWidget(backupModeComboBox_);
+  modeLayout->addStretch();
+  mainLayout->addLayout(modeLayout);
 
-    m_localDestinationGroupBox = new QGroupBox(tr("Local Destination Configuration"));
-    QGridLayout *localDestLayout = new QGridLayout(m_localDestinationGroupBox);
-    localDestLayout->addWidget(new QLabel(tr("Destination Directory (Local):")), 0, 0);
-    destinationDirEdit_ = new QLineEdit();
-    destinationDirEdit_->setReadOnly(true);
-    localDestLayout->addWidget(destinationDirEdit_, 0, 1);
-    destinationDirButton_ = new QPushButton(tr("Browse..."));
-    connect(destinationDirButton_, &QPushButton::clicked, this, &MainWindow::selectDestinationDirectory);
-    localDestLayout->addWidget(destinationDirButton_, 0, 2);
-    mainLayout->addWidget(m_localDestinationGroupBox);
+  QGroupBox *sourceGroupBox = new QGroupBox(tr("Source Configuration"));
+  QGridLayout *sourceLayout = new QGridLayout(sourceGroupBox);
+  sourceLayout->addWidget(new QLabel(tr("Source Directory:")), 0, 0);
+  sourceDirEdit_ = new QLineEdit();
+  sourceDirEdit_->setReadOnly(true);
+  sourceLayout->addWidget(sourceDirEdit_, 0, 1);
+  sourceDirButton_ = new QPushButton(tr("Browse..."));
+  connect(sourceDirButton_, &QPushButton::clicked, this,
+          &MainWindow::selectSourceDirectory);
+  sourceLayout->addWidget(sourceDirButton_, 0, 2);
+  mainLayout->addWidget(sourceGroupBox);
 
-    sftpSettingsGroupBox_ = new QGroupBox(tr("SFTP Configuration"));
-    QFormLayout *sftpFormLayout = new QFormLayout(sftpSettingsGroupBox_);
-    sftpHostLineEdit_ = new QLineEdit();
-    sftpFormLayout->addRow(new QLabel(tr("SFTP Host:")), sftpHostLineEdit_);
-    sftpPortLineEdit_ = new QLineEdit();
-    sftpPortLineEdit_->setText("22");
-    sftpPortLineEdit_->setValidator(new QIntValidator(1, 65535, this));
-    sftpFormLayout->addRow(new QLabel(tr("SFTP Port:")), sftpPortLineEdit_);
-    sftpUsernameLineEdit_ = new QLineEdit();
-    sftpFormLayout->addRow(new QLabel(tr("SFTP Username:")), sftpUsernameLineEdit_);
-    sftpPasswordLineEdit_ = new QLineEdit();
-    sftpPasswordLineEdit_->setEchoMode(QLineEdit::Password);
-    sftpFormLayout->addRow(new QLabel(tr("SFTP Password:")), sftpPasswordLineEdit_);
-    sftpSavePasswordCheckBox_ = new QCheckBox(tr("Save password securely"));
-    sftpFormLayout->addRow(sftpSavePasswordCheckBox_);
-    sftpRemotePathLineEdit_ = new QLineEdit();
-    sftpFormLayout->addRow(new QLabel(tr("SFTP Remote Path:")), sftpRemotePathLineEdit_);
-    sftpConnectToggleButton_ = new QPushButton(tr("Connect"));
-    sftpFormLayout->addRow(sftpConnectToggleButton_);
-    connect(sftpConnectToggleButton_, &QPushButton::clicked, this, &MainWindow::onSftpConnectToggleClicked);
-    mainLayout->addWidget(sftpSettingsGroupBox_);
+  m_localDestinationGroupBox =
+      new QGroupBox(tr("Local Destination Configuration"));
+  QGridLayout *localDestLayout = new QGridLayout(m_localDestinationGroupBox);
+  localDestLayout->addWidget(new QLabel(tr("Destination Directory (Local):")),
+                             0, 0);
+  destinationDirEdit_ = new QLineEdit();
+  destinationDirEdit_->setReadOnly(true);
+  localDestLayout->addWidget(destinationDirEdit_, 0, 1);
+  destinationDirButton_ = new QPushButton(tr("Browse..."));
+  connect(destinationDirButton_, &QPushButton::clicked, this,
+          &MainWindow::selectDestinationDirectory);
+  localDestLayout->addWidget(destinationDirButton_, 0, 2);
+  mainLayout->addWidget(m_localDestinationGroupBox);
 
-    gcsSettingsGroupBox_ = new QGroupBox(tr("Google Cloud Storage Configuration"));
-    QFormLayout *gcsFormLayout = new QFormLayout(gcsSettingsGroupBox_);
-    gcsBucketNameLineEdit_ = new QLineEdit();
-    gcsFormLayout->addRow(new QLabel(tr("GCS Bucket Name:")), gcsBucketNameLineEdit_);
-    gcsAccountIdentifierLineEdit_ = new QLineEdit();
-    gcsFormLayout->addRow(new QLabel(tr("GCS Account Identifier:")), gcsAccountIdentifierLineEdit_);
-    gcsConnectButton_ = new QPushButton(tr("Connect to Google Account"));
-    gcsFormLayout->addRow(gcsConnectButton_);
-    connect(gcsConnectButton_, &QPushButton::clicked, this, &MainWindow::onGcsConnectButtonClicked);
-    gcsAuthStatusLabel_ = new QLabel(tr("Status: Not Authenticated"));
-    gcsFormLayout->addRow(gcsAuthStatusLabel_);
-    gcsTestConnectionButton_ = new QPushButton(tr("Test Connection")); // Instantiate and add
-    gcsFormLayout->addRow(gcsTestConnectionButton_);
-    connect(gcsTestConnectionButton_, &QPushButton::clicked, this, &MainWindow::onGcsTestConnectionClicked);
-    gcsConnectToggleButton_ = new QPushButton(tr("Connect")); // For listing session
-    gcsFormLayout->addRow(gcsConnectToggleButton_);
-    connect(gcsConnectToggleButton_, &QPushButton::clicked, this, &MainWindow::onGcsConnectToggleClicked);
-    mainLayout->addWidget(gcsSettingsGroupBox_);
+  sftpSettingsGroupBox_ = new QGroupBox(tr("SFTP Configuration"));
+  QFormLayout *sftpFormLayout = new QFormLayout(sftpSettingsGroupBox_);
+  sftpHostLineEdit_ = new QLineEdit();
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Host:")), sftpHostLineEdit_);
+  sftpPortLineEdit_ = new QLineEdit();
+  sftpPortLineEdit_->setText("22");
+  sftpPortLineEdit_->setValidator(new QIntValidator(1, 65535, this));
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Port:")), sftpPortLineEdit_);
+  sftpUsernameLineEdit_ = new QLineEdit();
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Username:")),
+                         sftpUsernameLineEdit_);
+  sftpPasswordLineEdit_ = new QLineEdit();
+  sftpPasswordLineEdit_->setEchoMode(QLineEdit::Password);
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Password:")),
+                         sftpPasswordLineEdit_);
+  sftpSavePasswordCheckBox_ = new QCheckBox(tr("Save password securely"));
+  sftpFormLayout->addRow(sftpSavePasswordCheckBox_);
+  sftpRemotePathLineEdit_ = new QLineEdit();
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Remote Path:")),
+                         sftpRemotePathLineEdit_);
+  sftpConnectToggleButton_ = new QPushButton(tr("Connect"));
+  sftpFormLayout->addRow(sftpConnectToggleButton_);
+  connect(sftpConnectToggleButton_, &QPushButton::clicked, this,
+          &MainWindow::onSftpConnectToggleClicked);
+  mainLayout->addWidget(sftpSettingsGroupBox_);
 
-    connect(backupModeComboBox_, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &MainWindow::onBackupModeChanged);
+  gcsSettingsGroupBox_ =
+      new QGroupBox(tr("Google Cloud Storage Configuration"));
+  QFormLayout *gcsFormLayout = new QFormLayout(gcsSettingsGroupBox_);
+  gcsBucketNameLineEdit_ = new QLineEdit();
+  gcsFormLayout->addRow(new QLabel(tr("GCS Bucket Name:")),
+                        gcsBucketNameLineEdit_);
+  gcsAccountIdentifierLineEdit_ = new QLineEdit();
+  gcsFormLayout->addRow(new QLabel(tr("GCS Account Identifier:")),
+                        gcsAccountIdentifierLineEdit_);
+  gcsConnectButton_ = new QPushButton(tr("Connect to Google Account"));
+  gcsFormLayout->addRow(gcsConnectButton_);
+  connect(gcsConnectButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsConnectButtonClicked);
+  gcsAuthStatusLabel_ = new QLabel(tr("Status: Not Authenticated"));
+  gcsFormLayout->addRow(gcsAuthStatusLabel_);
+  gcsTestConnectionButton_ =
+      new QPushButton(tr("Test Connection")); // Instantiate and add
+  gcsFormLayout->addRow(gcsTestConnectionButton_);
+  connect(gcsTestConnectionButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsTestConnectionClicked);
+  gcsConnectToggleButton_ =
+      new QPushButton(tr("Connect")); // For listing session
+  gcsFormLayout->addRow(gcsConnectToggleButton_);
+  connect(gcsConnectToggleButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsConnectToggleClicked);
+  mainLayout->addWidget(gcsSettingsGroupBox_);
 
-    QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Controls"));
-    QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
-    scheduleLayout->addWidget(new QLabel(tr("Backup Time:")), 0, 0);
-    backupTimeEdit_ = new QTimeEdit();
-    backupTimeEdit_->setDisplayFormat("HH:mm");
-    scheduleLayout->addWidget(backupTimeEdit_, 0, 1);
-    addTimeButton_ = new QPushButton(tr("Add"));
-    scheduleLayout->addWidget(addTimeButton_, 0, 2);
-    connect(addTimeButton_, &QPushButton::clicked, this, &MainWindow::onAddBackupTimeClicked);
+  connect(backupModeComboBox_,
+          QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+          &MainWindow::onBackupModeChanged);
 
-    scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 1, 0, 1, 3);
-    timeListWidget_ = new QListWidget();
-    scheduleLayout->addWidget(timeListWidget_, 2, 0, 1, 3);
-    removeTimeButton_ = new QPushButton(tr("Remove Selected"));
-    scheduleLayout->addWidget(removeTimeButton_, 3, 0, 1, 3);
-    connect(removeTimeButton_, &QPushButton::clicked, this, &MainWindow::onRemoveBackupTimeClicked);
+  QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Controls"));
+  QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
+  scheduleLayout->addWidget(new QLabel(tr("Backup Time:")), 0, 0);
+  backupTimeEdit_ = new QTimeEdit();
+  backupTimeEdit_->setDisplayFormat("HH:mm");
+  scheduleLayout->addWidget(backupTimeEdit_, 0, 1);
+  QHBoxLayout *daysLayout = new QHBoxLayout();
+  const QStringList dayLabels = {tr("Mon"), tr("Tue"), tr("Wed"), tr("Thu"),
+                                 tr("Fri"), tr("Sat"), tr("Sun")};
+  for (int i = 0; i < 7; ++i) {
+    QCheckBox *cb = new QCheckBox(dayLabels[i]);
+    dayCheckBoxes_.append(cb);
+    daysLayout->addWidget(cb);
+  }
+  scheduleLayout->addLayout(daysLayout, 1, 0, 1, 3);
+  addTimeButton_ = new QPushButton(tr("Add"));
+  scheduleLayout->addWidget(addTimeButton_, 0, 2);
+  connect(addTimeButton_, &QPushButton::clicked, this,
+          &MainWindow::onAddBackupTimeClicked);
 
-    applyScheduleButton_ = new QPushButton(tr("Apply Schedule"));
-    connect(applyScheduleButton_, &QPushButton::clicked, this, &MainWindow::applySchedule);
-    scheduleLayout->addWidget(applyScheduleButton_, 4, 0, 1, 3);
-    runBackupButton_ = new QPushButton(tr("Run Backup Now"));
-    connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
-    scheduleLayout->addWidget(runBackupButton_, 5, 0, 1, 3);
-    mainLayout->addWidget(scheduleGroupBox);
+  scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 2, 0, 1, 3);
+  timeListWidget_ = new QListWidget();
+  scheduleLayout->addWidget(timeListWidget_, 3, 0, 1, 3);
+  removeTimeButton_ = new QPushButton(tr("Remove Selected"));
+  scheduleLayout->addWidget(removeTimeButton_, 4, 0, 1, 3);
+  connect(removeTimeButton_, &QPushButton::clicked, this,
+          &MainWindow::onRemoveBackupTimeClicked);
 
-    watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
-    QGridLayout *watchLayout = new QGridLayout(watchGroupBox_);
-    watchEnableCheckBox_ = new QCheckBox(tr("Activer la surveillance automatique de ce dossier"));
-    watchLayout->addWidget(watchEnableCheckBox_, 0, 0, 1, 3);
-    watchLayout->addWidget(new QLabel(tr("Dossier à surveiller:")), 1, 0);
-    watchDirEdit_ = new QLineEdit();
-    watchDirEdit_->setReadOnly(true);
-    watchLayout->addWidget(watchDirEdit_, 1, 1);
-    watchDirButton_ = new QPushButton(tr("Browse..."));
-    watchLayout->addWidget(watchDirButton_, 1, 2);
-    watchStatusLabel_ = new QLabel(tr("Surveillance inactive"));
-    watchLayout->addWidget(watchStatusLabel_, 2, 0, 1, 3);
-    mainLayout->addWidget(watchGroupBox_);
+  applyScheduleButton_ = new QPushButton(tr("Apply Schedule"));
+  connect(applyScheduleButton_, &QPushButton::clicked, this,
+          &MainWindow::applySchedule);
+  scheduleLayout->addWidget(applyScheduleButton_, 5, 0, 1, 3);
+  runBackupButton_ = new QPushButton(tr("Run Backup Now"));
+  connect(runBackupButton_, &QPushButton::clicked, this,
+          &MainWindow::runBackupNow);
+  scheduleLayout->addWidget(runBackupButton_, 6, 0, 1, 3);
+  mainLayout->addWidget(scheduleGroupBox);
 
-    connect(watchDirButton_, &QPushButton::clicked, this, &MainWindow::selectWatchDirectory);
-    connect(watchEnableCheckBox_, &QCheckBox::toggled, this, &MainWindow::onAutoWatchToggled);
+  watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
+  QGridLayout *watchLayout = new QGridLayout(watchGroupBox_);
+  watchEnableCheckBox_ =
+      new QCheckBox(tr("Activer la surveillance automatique de ce dossier"));
+  watchLayout->addWidget(watchEnableCheckBox_, 0, 0, 1, 3);
+  watchLayout->addWidget(new QLabel(tr("Dossier à surveiller:")), 1, 0);
+  watchDirEdit_ = new QLineEdit();
+  watchDirEdit_->setReadOnly(true);
+  watchLayout->addWidget(watchDirEdit_, 1, 1);
+  watchDirButton_ = new QPushButton(tr("Browse..."));
+  watchLayout->addWidget(watchDirButton_, 1, 2);
+  watchStatusLabel_ = new QLabel(tr("Surveillance inactive"));
+  watchLayout->addWidget(watchStatusLabel_, 2, 0, 1, 3);
+  mainLayout->addWidget(watchGroupBox_);
 
-    mainLayout->addWidget(new QLabel(tr("Logs:")));
-    logDisplay_ = new QTextEdit();
-    logDisplay_->setReadOnly(true);
-    mainLayout->addWidget(logDisplay_);
-    mainLayout->setStretchFactor(logDisplay_, 1);
+  connect(watchDirButton_, &QPushButton::clicked, this,
+          &MainWindow::selectWatchDirectory);
+  connect(watchEnableCheckBox_, &QCheckBox::toggled, this,
+          &MainWindow::onAutoWatchToggled);
 
-    // File Viewer GroupBox within a DockWidget
-    fileViewerGroupBox_ = new QGroupBox(tr("Remote File Viewer"));
-    QVBoxLayout *fileViewerLayout = new QVBoxLayout(); // No parent here, will be set on the group box
+  mainLayout->addWidget(new QLabel(tr("Logs:")));
+  logDisplay_ = new QTextEdit();
+  logDisplay_->setReadOnly(true);
+  mainLayout->addWidget(logDisplay_);
+  mainLayout->setStretchFactor(logDisplay_, 1);
 
-    currentPathLabel_ = new QLabel(tr("Path: /"), fileViewerGroupBox_); // Parented
-    fileTableWidget_ = new QTableWidget(fileViewerGroupBox_); // Parented
-    fileTableWidget_->setColumnCount(4);
-    QStringList headers = {tr("Name"), tr("Size"), tr("Date Modified"), tr("Type")};
-    fileTableWidget_->setHorizontalHeaderLabels(headers);
-    fileTableWidget_->setSelectionBehavior(QAbstractItemView::SelectRows);
-    fileTableWidget_->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    fileTableWidget_->setSelectionMode(QAbstractItemView::SingleSelection);
-    fileTableWidget_->verticalHeader()->setVisible(false);
-    fileTableWidget_->horizontalHeader()->setStretchLastSection(true);
-    fileTableWidget_->setSortingEnabled(true); // Enable sorting
+  // File Viewer GroupBox within a DockWidget
+  fileViewerGroupBox_ = new QGroupBox(tr("Remote File Viewer"));
+  QVBoxLayout *fileViewerLayout =
+      new QVBoxLayout(); // No parent here, will be set on the group box
 
-    refreshButton_ = new QPushButton(tr("Refresh"), fileViewerGroupBox_); // Parented
-    downloadButton_ = new QPushButton(tr("Download"), fileViewerGroupBox_); // Parented
-    deleteButton_ = new QPushButton(tr("Delete"), fileViewerGroupBox_); // Parented
+  currentPathLabel_ =
+      new QLabel(tr("Path: /"), fileViewerGroupBox_);       // Parented
+  fileTableWidget_ = new QTableWidget(fileViewerGroupBox_); // Parented
+  fileTableWidget_->setColumnCount(4);
+  QStringList headers = {tr("Name"), tr("Size"), tr("Date Modified"),
+                         tr("Type")};
+  fileTableWidget_->setHorizontalHeaderLabels(headers);
+  fileTableWidget_->setSelectionBehavior(QAbstractItemView::SelectRows);
+  fileTableWidget_->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  fileTableWidget_->setSelectionMode(QAbstractItemView::SingleSelection);
+  fileTableWidget_->verticalHeader()->setVisible(false);
+  fileTableWidget_->horizontalHeader()->setStretchLastSection(true);
+  fileTableWidget_->setSortingEnabled(true); // Enable sorting
 
-    QHBoxLayout *buttonLayout = new QHBoxLayout(); // No parent here
-    buttonLayout->addWidget(refreshButton_);
-    buttonLayout->addWidget(downloadButton_);
-    buttonLayout->addWidget(deleteButton_);
-    buttonLayout->addStretch();
+  refreshButton_ =
+      new QPushButton(tr("Refresh"), fileViewerGroupBox_); // Parented
+  downloadButton_ =
+      new QPushButton(tr("Download"), fileViewerGroupBox_); // Parented
+  deleteButton_ =
+      new QPushButton(tr("Delete"), fileViewerGroupBox_); // Parented
 
-    fileViewerLayout->addWidget(currentPathLabel_);
-    fileViewerLayout->addWidget(fileTableWidget_);
-    fileViewerLayout->addLayout(buttonLayout);
-    fileViewerGroupBox_->setLayout(fileViewerLayout);
+  QHBoxLayout *buttonLayout = new QHBoxLayout(); // No parent here
+  buttonLayout->addWidget(refreshButton_);
+  buttonLayout->addWidget(downloadButton_);
+  buttonLayout->addWidget(deleteButton_);
+  buttonLayout->addStretch();
 
-    fileViewerDockWidget_ = new QDockWidget(tr("Remote File Viewer"), this);
-    fileViewerDockWidget_->setWidget(fileViewerGroupBox_);
-    addDockWidget(Qt::RightDockWidgetArea, fileViewerDockWidget_);
-    fileViewerDockWidget_->hide();
-    viewMenu->addAction(fileViewerDockWidget_->toggleViewAction());
+  fileViewerLayout->addWidget(currentPathLabel_);
+  fileViewerLayout->addWidget(fileTableWidget_);
+  fileViewerLayout->addLayout(buttonLayout);
+  fileViewerGroupBox_->setLayout(fileViewerLayout);
 
-    // Connect file viewer signals
-    connect(refreshButton_, &QPushButton::clicked, this, &MainWindow::onFileViewerRefreshClicked);
-    connect(downloadButton_, &QPushButton::clicked, this, &MainWindow::onFileViewerDownloadClicked);
-    connect(deleteButton_, &QPushButton::clicked, this, &MainWindow::onFileViewerDeleteClicked);
-    connect(fileTableWidget_, &QTableWidget::itemDoubleClicked, this, &MainWindow::onFileTableItemDoubleClicked);
+  fileViewerDockWidget_ = new QDockWidget(tr("Remote File Viewer"), this);
+  fileViewerDockWidget_->setWidget(fileViewerGroupBox_);
+  addDockWidget(Qt::RightDockWidgetArea, fileViewerDockWidget_);
+  fileViewerDockWidget_->hide();
+  viewMenu->addAction(fileViewerDockWidget_->toggleViewAction());
 
-    fileDialog_ = new QFileDialog(this);
+  // Connect file viewer signals
+  connect(refreshButton_, &QPushButton::clicked, this,
+          &MainWindow::onFileViewerRefreshClicked);
+  connect(downloadButton_, &QPushButton::clicked, this,
+          &MainWindow::onFileViewerDownloadClicked);
+  connect(deleteButton_, &QPushButton::clicked, this,
+          &MainWindow::onFileViewerDeleteClicked);
+  connect(fileTableWidget_, &QTableWidget::itemDoubleClicked, this,
+          &MainWindow::onFileTableItemDoubleClicked);
+
+  fileDialog_ = new QFileDialog(this);
 }
 
 void MainWindow::selectSourceDirectory() {
-    fileDialog_->setWindowTitle(tr("Select Source Directory"));
-    fileDialog_->setFileMode(QFileDialog::Directory);
-    fileDialog_->setOption(QFileDialog::ShowDirsOnly, true);
-    QString initialPath = sourceDirEdit_->text().isEmpty() ? QStandardPaths::writableLocation(QStandardPaths::HomeLocation) : sourceDirEdit_->text();
-    QString directory = fileDialog_->getExistingDirectory(this, tr("Select Source Directory"), initialPath);
-    if (!directory.isEmpty()) {
-        sourceDirEdit_->setText(QDir::toNativeSeparators(directory));
-        updateLog(QString("Source directory selected: %1").arg(directory));
-    }
+  fileDialog_->setWindowTitle(tr("Select Source Directory"));
+  fileDialog_->setFileMode(QFileDialog::Directory);
+  fileDialog_->setOption(QFileDialog::ShowDirsOnly, true);
+  QString initialPath =
+      sourceDirEdit_->text().isEmpty()
+          ? QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+          : sourceDirEdit_->text();
+  QString directory = fileDialog_->getExistingDirectory(
+      this, tr("Select Source Directory"), initialPath);
+  if (!directory.isEmpty()) {
+    sourceDirEdit_->setText(QDir::toNativeSeparators(directory));
+    updateLog(QString("Source directory selected: %1").arg(directory));
+  }
 }
 
 void MainWindow::selectDestinationDirectory() {
-    fileDialog_->setWindowTitle(tr("Select Destination Directory"));
-    fileDialog_->setFileMode(QFileDialog::Directory);
-    fileDialog_->setOption(QFileDialog::ShowDirsOnly, true);
-    QString initialPath = destinationDirEdit_->text().isEmpty() ? QStandardPaths::writableLocation(QStandardPaths::HomeLocation) : destinationDirEdit_->text();
-    QString directory = fileDialog_->getExistingDirectory(this, tr("Select Destination Directory"), initialPath);
-    if (!directory.isEmpty()) {
-        destinationDirEdit_->setText(QDir::toNativeSeparators(directory));
-        updateLog(QString("Destination directory selected: %1").arg(directory));
-    }
+  fileDialog_->setWindowTitle(tr("Select Destination Directory"));
+  fileDialog_->setFileMode(QFileDialog::Directory);
+  fileDialog_->setOption(QFileDialog::ShowDirsOnly, true);
+  QString initialPath =
+      destinationDirEdit_->text().isEmpty()
+          ? QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+          : destinationDirEdit_->text();
+  QString directory = fileDialog_->getExistingDirectory(
+      this, tr("Select Destination Directory"), initialPath);
+  if (!directory.isEmpty()) {
+    destinationDirEdit_->setText(QDir::toNativeSeparators(directory));
+    updateLog(QString("Destination directory selected: %1").arg(directory));
+  }
 }
 
 void MainWindow::onAddBackupTimeClicked() {
-    QTime t = backupTimeEdit_->time();
-    if (!t.isValid()) return;
-    QString text = t.toString("HH:mm");
-    if (timeListWidget_->findItems(text, Qt::MatchExactly).isEmpty()) {
-        timeListWidget_->addItem(text);
+  QTime t = backupTimeEdit_->time();
+  if (!t.isValid())
+    return;
+  QStringList dayNames;
+  QStringList dayNums;
+  for (int i = 0; i < dayCheckBoxes_.size(); ++i) {
+    if (dayCheckBoxes_[i]->isChecked()) {
+      dayNames << dayCheckBoxes_[i]->text();
+      dayNums << QString::number(i + 1); // Qt day numbers
     }
+  }
+  QString dataString = t.toString("HH:mm");
+  if (!dayNums.isEmpty())
+    dataString += "|" + dayNums.join(',');
+
+  for (int i = 0; i < timeListWidget_->count(); ++i) {
+    if (timeListWidget_->item(i)->data(Qt::UserRole).toString() == dataString)
+      return; // duplicate
+  }
+
+  QString display = t.toString("HH:mm");
+  if (!dayNames.isEmpty())
+    display += " (" + dayNames.join(',') + ")";
+  else
+    display += tr(" (All)");
+  QListWidgetItem *item = new QListWidgetItem(display);
+  item->setData(Qt::UserRole, dataString);
+  timeListWidget_->addItem(item);
+  for (QCheckBox *cb : dayCheckBoxes_)
+    cb->setChecked(false);
 }
 
 void MainWindow::onRemoveBackupTimeClicked() {
-    qDeleteAll(timeListWidget_->selectedItems());
+  qDeleteAll(timeListWidget_->selectedItems());
 }
 
 void MainWindow::selectWatchDirectory() {
-    fileDialog_->setWindowTitle(tr("Select Directory to Watch"));
-    fileDialog_->setFileMode(QFileDialog::Directory);
-    fileDialog_->setOption(QFileDialog::ShowDirsOnly, true);
-    QString initialPath = watchDirEdit_->text().isEmpty() ? QStandardPaths::writableLocation(QStandardPaths::HomeLocation) : watchDirEdit_->text();
-    QString directory = fileDialog_->getExistingDirectory(this, tr("Select Directory to Watch"), initialPath);
-    if (!directory.isEmpty()) {
-        watchDirEdit_->setText(QDir::toNativeSeparators(directory));
-        if (watchEnableCheckBox_->isChecked()) {
-            onAutoWatchToggled(true);
-        }
+  fileDialog_->setWindowTitle(tr("Select Directory to Watch"));
+  fileDialog_->setFileMode(QFileDialog::Directory);
+  fileDialog_->setOption(QFileDialog::ShowDirsOnly, true);
+  QString initialPath =
+      watchDirEdit_->text().isEmpty()
+          ? QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+          : watchDirEdit_->text();
+  QString directory = fileDialog_->getExistingDirectory(
+      this, tr("Select Directory to Watch"), initialPath);
+  if (!directory.isEmpty()) {
+    watchDirEdit_->setText(QDir::toNativeSeparators(directory));
+    if (watchEnableCheckBox_->isChecked()) {
+      onAutoWatchToggled(true);
     }
+  }
 }
 
 void MainWindow::onAutoWatchToggled(bool checked) {
-    dirWatcher_->removePaths(dirWatcher_->directories());
-    if (checked) {
-        QString dir = watchDirEdit_->text();
-        if (!dir.isEmpty()) {
-            dirWatcher_->addPath(dir);
-            watchStatusLabel_->setText(tr("Surveillance active"));
-        } else {
-            watchStatusLabel_->setText(tr("No directory set"));
-        }
+  dirWatcher_->removePaths(dirWatcher_->directories());
+  if (checked) {
+    QString dir = watchDirEdit_->text();
+    if (!dir.isEmpty()) {
+      dirWatcher_->addPath(dir);
+      watchStatusLabel_->setText(tr("Surveillance active"));
     } else {
-        watchStatusLabel_->setText(tr("Surveillance inactive"));
+      watchStatusLabel_->setText(tr("No directory set"));
     }
+  } else {
+    watchStatusLabel_->setText(tr("Surveillance inactive"));
+  }
 }
 
-void MainWindow::onDirectoryChanged(const QString& path) {
-    Q_UNUSED(path);
-    watchStatusLabel_->setText(tr("Dernier changement: %1").arg(QDateTime::currentDateTime().toString()));
-    watchTriggerTimer_->start(3000);
+void MainWindow::onDirectoryChanged(const QString &path) {
+  Q_UNUSED(path);
+  watchStatusLabel_->setText(tr("Dernier changement: %1")
+                                 .arg(QDateTime::currentDateTime().toString()));
+  watchTriggerTimer_->start(3000);
 }
 
 void MainWindow::onWatchTimerTimeout() {
-    updateLog(tr("Modification détectée, lancement de la sauvegarde."));
-    runBackupNow();
+  updateLog(tr("Modification détectée, lancement de la sauvegarde."));
+  runBackupNow();
 }
 
 void MainWindow::applySchedule() {
-    QString sourcePath = sourceDirEdit_->text();
-    QList<QTime> times;
-    for (int i = 0; i < timeListWidget_->count(); ++i) {
-        QTime t = QTime::fromString(timeListWidget_->item(i)->text(), "HH:mm");
-        if (t.isValid()) times.append(t);
+  QString sourcePath = sourceDirEdit_->text();
+  QList<ScheduleEntry> entries;
+  for (int i = 0; i < timeListWidget_->count(); ++i) {
+    QString data = timeListWidget_->item(i)->data(Qt::UserRole).toString();
+    QStringList parts = data.split('|');
+    QTime t = QTime::fromString(parts.value(0), "HH:mm");
+    if (!t.isValid())
+      continue;
+    ScheduleEntry se;
+    se.time = t;
+    if (parts.size() > 1) {
+      QStringList ds = parts[1].split(',');
+      for (const QString &dsItem : ds) {
+        bool ok = false;
+        int val = dsItem.toInt(&ok);
+        if (ok)
+          se.days.insert(static_cast<Qt::DayOfWeek>(val));
+      }
     }
+    entries.append(se);
+  }
 
-    if (sourcePath.isEmpty()) {
-        QMessageBox::warning(this, tr("Configuration Error"), tr("Source path cannot be empty."));
-        updateLog("Error: Failed to apply schedule. Source path empty.");
-        return;
+  if (sourcePath.isEmpty()) {
+    QMessageBox::warning(this, tr("Configuration Error"),
+                         tr("Source path cannot be empty."));
+    updateLog("Error: Failed to apply schedule. Source path empty.");
+    return;
+  }
+  if (entries.isEmpty()) {
+    QMessageBox::warning(this, tr("Configuration Error"),
+                         tr("At least one backup time must be added."));
+    updateLog("Error: Failed to apply schedule. No times added.");
+    return;
+  }
+
+  QString effectiveDestPathOrIdentifier;
+  QString currentModeText = backupModeComboBox_->currentText();
+  bool localMode = (currentModeText == tr("Local Backup"));
+  bool sftpMode = (currentModeText == tr("SFTP Backup"));
+  bool gcsMode = (currentModeText == tr("Google Cloud Storage"));
+
+  if (localMode) {
+    effectiveDestPathOrIdentifier = destinationDirEdit_->text();
+    if (effectiveDestPathOrIdentifier.isEmpty()) {
+      QMessageBox::warning(
+          this, tr("Configuration Error"),
+          tr("Destination path cannot be empty for local backup."));
+      updateLog("Error: Failed to apply schedule for Local Backup. Destination "
+                "path empty.");
+      return;
     }
-    if (times.isEmpty()) {
-        QMessageBox::warning(this, tr("Configuration Error"), tr("At least one backup time must be added."));
-        updateLog("Error: Failed to apply schedule. No times added.");
-        return;
+    scheduler_->setDailyBackupTask(
+        sourcePath, effectiveDestPathOrIdentifier, entries, true, false,
+        QString(),                      // sftpHost is QString
+        0, QString(), QString(), false, // isGcsMode is bool
+        QString(), QString());
+    updateLog(
+        QString("Schedule applied for Local Backup: %1 to %2 with %3 times")
+            .arg(sourcePath, effectiveDestPathOrIdentifier)
+            .arg(entries.size()));
+
+  } else if (sftpMode) {
+    if (sftpHostLineEdit_->text().isEmpty() ||
+        sftpUsernameLineEdit_->text().isEmpty() ||
+        sftpRemotePathLineEdit_->text().isEmpty()) {
+      QMessageBox::warning(this, tr("Configuration Error"),
+                           tr("SFTP Host, Username, and Remote Path cannot be "
+                              "empty for SFTP mode."));
+      updateLog(
+          "Error: Failed to apply schedule for SFTP. Required fields missing.");
+      return;
     }
+    effectiveDestPathOrIdentifier =
+        QString("sftp://%1%2")
+            .arg(sftpHostLineEdit_->text(), sftpRemotePathLineEdit_->text());
 
-    QString effectiveDestPathOrIdentifier;
-    QString currentModeText = backupModeComboBox_->currentText();
-    bool localMode = (currentModeText == tr("Local Backup"));
-    bool sftpMode = (currentModeText == tr("SFTP Backup"));
-    bool gcsMode = (currentModeText == tr("Google Cloud Storage"));
-
-    if (localMode) {
-        effectiveDestPathOrIdentifier = destinationDirEdit_->text();
-        if (effectiveDestPathOrIdentifier.isEmpty()) {
-            QMessageBox::warning(this, tr("Configuration Error"), tr("Destination path cannot be empty for local backup."));
-            updateLog("Error: Failed to apply schedule for Local Backup. Destination path empty.");
-            return;
-        }
-        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, times, true,
-                                       false, QString(),      // sftpHost is QString
-                                       0, QString(), QString(), false, // isGcsMode is bool
-                                       QString(), QString());
-        updateLog(QString("Schedule applied for Local Backup: %1 to %2 with %3 times")
-                      .arg(sourcePath, effectiveDestPathOrIdentifier)
-                      .arg(times.size()));
-
-    } else if (sftpMode) {
-        if (sftpHostLineEdit_->text().isEmpty() || sftpUsernameLineEdit_->text().isEmpty() || sftpRemotePathLineEdit_->text().isEmpty()) {
-             QMessageBox::warning(this, tr("Configuration Error"), tr("SFTP Host, Username, and Remote Path cannot be empty for SFTP mode."));
-             updateLog("Error: Failed to apply schedule for SFTP. Required fields missing.");
-             return;
-        }
-        effectiveDestPathOrIdentifier = QString("sftp://%1%2").arg(sftpHostLineEdit_->text(), sftpRemotePathLineEdit_->text());
-        
-        if (m_credentialManager) {
-            QString serviceName = QString("sftp_%1_%2").arg(sftpHostLineEdit_->text()).arg(sftpPortLineEdit_->text().toInt());
-            QString qUsername = sftpUsernameLineEdit_->text();
-            QString qPassword = sftpPasswordLineEdit_->text();
-            if (sftpSavePasswordCheckBox_->isChecked()) {
-                if (!qPassword.isEmpty()) m_credentialManager->storeSecret(serviceName, qUsername, qPassword);
-            } else {
-                m_credentialManager->deleteSecret(serviceName, qUsername);
-            }
-        }
-        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, times, true,
-                                       true, sftpHostLineEdit_->text(), // sftpHost
-                                       sftpPortLineEdit_->text().toInt(),
-                                       sftpUsernameLineEdit_->text(),
-                                       sftpRemotePathLineEdit_->text(),
-                                       false, QString(), QString()); // isGcsMode, gcsBucketName, gcsObjectPrefix
-        updateLog(QString("Schedule applied for SFTP Backup: %1 to %2 with %3 times")
-                      .arg(sourcePath, effectiveDestPathOrIdentifier)
-                      .arg(times.size()));
-
-    } else if (gcsMode) {
-        QString bucketName = gcsBucketNameLineEdit_->text();
-        QString accountId = gcsAccountIdentifierLineEdit_->text();
-        if (bucketName.isEmpty() || accountId.isEmpty()) {
-            QMessageBox::warning(this, tr("Configuration Error"), tr("GCS Bucket Name and Account Identifier cannot be empty for GCS mode."));
-            updateLog("Error: Failed to apply schedule for GCS. Bucket Name or Account ID missing.");
-            return;
-        }
-        effectiveDestPathOrIdentifier = QString("gcs://%1").arg(bucketName);
-        scheduler_->setDailyBackupTask(sourcePath, effectiveDestPathOrIdentifier, times, true,
-                                       false, QString(),      // sftpHost is QString
-                                       0, QString(), QString(), true, // isGcsMode is bool
-                                       bucketName, accountId);
-        updateLog(QString("Schedule applied for GCS Backup: %1 to bucket '%2' (Account: %3) with %4 times")
-                      .arg(sourcePath, bucketName, accountId)
-                      .arg(times.size()));
-    } else {
-        QMessageBox::critical(this, tr("Internal Error"), tr("Unknown backup mode selected."));
-        updateLog("Error: Apply schedule failed. Unknown backup mode.");
-        return;
+    if (m_credentialManager) {
+      QString serviceName = QString("sftp_%1_%2")
+                                .arg(sftpHostLineEdit_->text())
+                                .arg(sftpPortLineEdit_->text().toInt());
+      QString qUsername = sftpUsernameLineEdit_->text();
+      QString qPassword = sftpPasswordLineEdit_->text();
+      if (sftpSavePasswordCheckBox_->isChecked()) {
+        if (!qPassword.isEmpty())
+          m_credentialManager->storeSecret(serviceName, qUsername, qPassword);
+      } else {
+        m_credentialManager->deleteSecret(serviceName, qUsername);
+      }
     }
+    scheduler_->setDailyBackupTask(
+        sourcePath, effectiveDestPathOrIdentifier, entries, true, true,
+        sftpHostLineEdit_->text(), // sftpHost
+        sftpPortLineEdit_->text().toInt(), sftpUsernameLineEdit_->text(),
+        sftpRemotePathLineEdit_->text(), false, QString(),
+        QString()); // isGcsMode, gcsBucketName, gcsObjectPrefix
+    updateLog(
+        QString("Schedule applied for SFTP Backup: %1 to %2 with %3 times")
+            .arg(sourcePath, effectiveDestPathOrIdentifier)
+            .arg(entries.size()));
 
-    QMessageBox::information(this, tr("Schedule Updated"), tr("Backup schedule has been updated and saved."));
+  } else if (gcsMode) {
+    QString bucketName = gcsBucketNameLineEdit_->text();
+    QString accountId = gcsAccountIdentifierLineEdit_->text();
+    if (bucketName.isEmpty() || accountId.isEmpty()) {
+      QMessageBox::warning(this, tr("Configuration Error"),
+                           tr("GCS Bucket Name and Account Identifier cannot "
+                              "be empty for GCS mode."));
+      updateLog("Error: Failed to apply schedule for GCS. Bucket Name or "
+                "Account ID missing.");
+      return;
+    }
+    effectiveDestPathOrIdentifier = QString("gcs://%1").arg(bucketName);
+    scheduler_->setDailyBackupTask(
+        sourcePath, effectiveDestPathOrIdentifier, entries, true, false,
+        QString(),                     // sftpHost is QString
+        0, QString(), QString(), true, // isGcsMode is bool
+        bucketName, accountId);
+    updateLog(QString("Schedule applied for GCS Backup: %1 to bucket '%2' "
+                      "(Account: %3) with %4 times")
+                  .arg(sourcePath, bucketName, accountId)
+                  .arg(entries.size()));
+  } else {
+    QMessageBox::critical(this, tr("Internal Error"),
+                          tr("Unknown backup mode selected."));
+    updateLog("Error: Apply schedule failed. Unknown backup mode.");
+    return;
+  }
+
+  QMessageBox::information(this, tr("Schedule Updated"),
+                           tr("Backup schedule has been updated and saved."));
 }
 
 void MainWindow::runBackupNow() {
-    QString sourcePath = sourceDirEdit_->text();
-    if (sourcePath.isEmpty()) {
-        QMessageBox::warning(this, tr("Backup Error"), tr("Source path must be configured."));
-        updateLog("Error: Manual backup failed. Source path empty.");
-        return;
+  QString sourcePath = sourceDirEdit_->text();
+  if (sourcePath.isEmpty()) {
+    QMessageBox::warning(this, tr("Backup Error"),
+                         tr("Source path must be configured."));
+    updateLog("Error: Manual backup failed. Source path empty.");
+    return;
+  }
+
+  QString currentModeText = backupModeComboBox_->currentText();
+  bool localMode = (currentModeText == tr("Local Backup"));
+  bool sftpMode = (currentModeText == tr("SFTP Backup"));
+  bool gcsMode = (currentModeText == tr("Google Cloud Storage"));
+
+  IStorageTarget *backupOperationTarget =
+      nullptr; // Use a local variable for the backup operation
+  // Do NOT delete this->sftpTarget_ or this->gcsTarget_ here as they are used
+  // by the viewer. this->localTarget_ is not used by a viewer, so it can be
+  // managed/deleted if it was from a previous runBackupNow. For simplicity and
+  // consistency, we'll create temporary targets for all modes in this function.
+  // If this->localTarget_ was used by a previous runBackupNow, it will be
+  // orphaned if not deleted. However, the current design deletes it in the
+  // destructor or if runBackupNow is called again for local. Let's ensure it's
+  // cleared if it's specific to this one-off backup. A cleaner approach is to
+  // always use temporary for runBackupNow for all types.
+  if (this->localTarget_) { // If it's from a previous runBackupNow call
+                            // specifically for local.
+    delete this->localTarget_;
+    this->localTarget_ = nullptr;
+  }
+
+  if (localMode) {
+    updateLog("Local Mode selected for manual backup.");
+    QString destPath = destinationDirEdit_->text();
+    if (destPath.isEmpty()) {
+      QMessageBox::warning(
+          this, tr("Backup Error"),
+          tr("Destination path must be configured for local backup."));
+      updateLog("Error: Manual backup failed. Local destination path empty.");
+      return;
     }
+    std::filesystem::path fsSourcePath(sourcePath.toStdString());
+    std::filesystem::path fsDestinationPathFromUI(destPath.toStdString());
+    std::filesystem::path backupRootForTarget =
+        fsDestinationPathFromUI / fsSourcePath.filename();
+    LocalTarget *tempLocalTarget =
+        new LocalTarget(backupRootForTarget.string()); // Temporary instance
+    backupOperationTarget = tempLocalTarget;
+    updateLog(QString("Manual Local backup started: From '%1' to '%2'.")
+                  .arg(sourcePath, destPath));
 
-    QString currentModeText = backupModeComboBox_->currentText();
-    bool localMode = (currentModeText == tr("Local Backup"));
-    bool sftpMode = (currentModeText == tr("SFTP Backup"));
-    bool gcsMode = (currentModeText == tr("Google Cloud Storage"));
-
-    IStorageTarget* backupOperationTarget = nullptr; // Use a local variable for the backup operation
-    // Do NOT delete this->sftpTarget_ or this->gcsTarget_ here as they are used by the viewer.
-    // this->localTarget_ is not used by a viewer, so it can be managed/deleted if it was from a previous runBackupNow.
-    // For simplicity and consistency, we'll create temporary targets for all modes in this function.
-    // If this->localTarget_ was used by a previous runBackupNow, it will be orphaned if not deleted.
-    // However, the current design deletes it in the destructor or if runBackupNow is called again for local.
-    // Let's ensure it's cleared if it's specific to this one-off backup.
-    // A cleaner approach is to always use temporary for runBackupNow for all types.
-    if (this->localTarget_) { // If it's from a previous runBackupNow call specifically for local.
-        delete this->localTarget_;
-        this->localTarget_ = nullptr;
+  } else if (sftpMode) {
+    updateLog("SFTP Mode selected for manual backup.");
+    if (sftpHostLineEdit_->text().isEmpty() ||
+        sftpUsernameLineEdit_->text().isEmpty() ||
+        sftpRemotePathLineEdit_->text().isEmpty()) {
+      QMessageBox::warning(
+          this, tr("Backup Error"),
+          tr("SFTP Host, Username, and Remote Path must be configured."));
+      updateLog(
+          "Error: Manual SFTP backup failed. Required SFTP fields missing.");
+      return;
     }
+    std::map<std::string, std::string> sftpConfig;
+    sftpConfig["host"] = sftpHostLineEdit_->text().toStdString();
+    sftpConfig["port"] = sftpPortLineEdit_->text().toStdString();
+    sftpConfig["username"] = sftpUsernameLineEdit_->text().toStdString();
+    sftpConfig["remoteBasePath"] =
+        sftpRemotePathLineEdit_->text().toStdString();
+    QString qPasswordFromField = sftpPasswordLineEdit_->text();
+    if (!qPasswordFromField.isEmpty())
+      sftpConfig["password"] = qPasswordFromField.toStdString();
+    SftpTarget *tempSftpTarget =
+        new SftpTarget(sftpConfig); // Temporary instance
+    backupOperationTarget = tempSftpTarget;
+    updateLog(QString("Manual SFTP backup started: From '%1' to host '%2'.")
+                  .arg(sourcePath, QString::fromStdString(sftpConfig["host"])));
 
-
-    if (localMode) {
-        updateLog("Local Mode selected for manual backup.");
-        QString destPath = destinationDirEdit_->text();
-        if (destPath.isEmpty()) {
-            QMessageBox::warning(this, tr("Backup Error"), tr("Destination path must be configured for local backup."));
-            updateLog("Error: Manual backup failed. Local destination path empty.");
-            return;
-        }
-        std::filesystem::path fsSourcePath(sourcePath.toStdString());
-        std::filesystem::path fsDestinationPathFromUI(destPath.toStdString());
-        std::filesystem::path backupRootForTarget = fsDestinationPathFromUI / fsSourcePath.filename();
-        LocalTarget* tempLocalTarget = new LocalTarget(backupRootForTarget.string()); // Temporary instance
-        backupOperationTarget = tempLocalTarget;
-        updateLog(QString("Manual Local backup started: From '%1' to '%2'.").arg(sourcePath, destPath));
-
-    } else if (sftpMode) {
-        updateLog("SFTP Mode selected for manual backup.");
-        if (sftpHostLineEdit_->text().isEmpty() || sftpUsernameLineEdit_->text().isEmpty() || sftpRemotePathLineEdit_->text().isEmpty()) {
-             QMessageBox::warning(this, tr("Backup Error"), tr("SFTP Host, Username, and Remote Path must be configured."));
-             updateLog("Error: Manual SFTP backup failed. Required SFTP fields missing.");
-             return;
-        }
-        std::map<std::string, std::string> sftpConfig;
-        sftpConfig["host"] = sftpHostLineEdit_->text().toStdString();
-        sftpConfig["port"] = sftpPortLineEdit_->text().toStdString();
-        sftpConfig["username"] = sftpUsernameLineEdit_->text().toStdString();
-        sftpConfig["remoteBasePath"] = sftpRemotePathLineEdit_->text().toStdString();
-        QString qPasswordFromField = sftpPasswordLineEdit_->text();
-        if (!qPasswordFromField.isEmpty()) sftpConfig["password"] = qPasswordFromField.toStdString();
-        SftpTarget* tempSftpTarget = new SftpTarget(sftpConfig); // Temporary instance
-        backupOperationTarget = tempSftpTarget;
-        updateLog(QString("Manual SFTP backup started: From '%1' to host '%2'.").arg(sourcePath, QString::fromStdString(sftpConfig["host"])));
-
-    } else if (gcsMode) {
-        updateLog("GCS Mode selected for manual backup.");
-        QString bucketName = gcsBucketNameLineEdit_->text();
-        QString accountId = gcsAccountIdentifierLineEdit_->text();
-        if (bucketName.isEmpty() || accountId.isEmpty()) {
-            QMessageBox::warning(this, tr("Backup Error"), tr("GCS Bucket Name and Account Identifier must be configured."));
-            updateLog("Error: Manual GCS backup failed. Bucket Name or Account ID missing.");
-            return;
-        }
-        std::map<std::string, std::string> gcsConfig;
-        gcsConfig["gcs_bucket_name"] = bucketName.toStdString();
-        gcsConfig["gcs_account_identifier"] = accountId.toStdString();
-        gcsConfig["gcs_object_prefix"] = ""; // For backups, prefix might be source folder name, handled by target.
-
-        GcsTarget* tempGcsTarget = new GcsTarget(gcsConfig, m_credentialManager.get()); // Temporary instance
-        backupOperationTarget = tempGcsTarget;
-        updateLog(QString("Manual GCS backup started: From '%1' to GCS Bucket '%2' (Account: '%3')")
-                      .arg(sourcePath, bucketName, accountId));
-    } else {
-        QMessageBox::critical(this, tr("Internal Error"), tr("Unknown backup mode selected for manual backup."));
-        updateLog("Error: Manual backup failed. Unknown backup mode.");
-        return;
+  } else if (gcsMode) {
+    updateLog("GCS Mode selected for manual backup.");
+    QString bucketName = gcsBucketNameLineEdit_->text();
+    QString accountId = gcsAccountIdentifierLineEdit_->text();
+    if (bucketName.isEmpty() || accountId.isEmpty()) {
+      QMessageBox::warning(
+          this, tr("Backup Error"),
+          tr("GCS Bucket Name and Account Identifier must be configured."));
+      updateLog("Error: Manual GCS backup failed. Bucket Name or Account ID "
+                "missing.");
+      return;
     }
+    std::map<std::string, std::string> gcsConfig;
+    gcsConfig["gcs_bucket_name"] = bucketName.toStdString();
+    gcsConfig["gcs_account_identifier"] = accountId.toStdString();
+    gcsConfig["gcs_object_prefix"] = ""; // For backups, prefix might be source
+                                         // folder name, handled by target.
 
-    if (!backupOperationTarget) { // Check the local variable
-        QMessageBox::critical(this, tr("Backup Error"), tr("Failed to initialize backup target."));
-        updateLog("Error: Manual backup failed. Target initialization failed.");
-        return;
-    }
-    
-    performBackupInternal(sourcePath, backupOperationTarget);
+    GcsTarget *tempGcsTarget = new GcsTarget(
+        gcsConfig, m_credentialManager.get()); // Temporary instance
+    backupOperationTarget = tempGcsTarget;
+    updateLog(QString("Manual GCS backup started: From '%1' to GCS Bucket '%2' "
+                      "(Account: '%3')")
+                  .arg(sourcePath, bucketName, accountId));
+  } else {
+    QMessageBox::critical(
+        this, tr("Internal Error"),
+        tr("Unknown backup mode selected for manual backup."));
+    updateLog("Error: Manual backup failed. Unknown backup mode.");
+    return;
+  }
 
-    // Clean up the temporary target used for this backup operation
-    // performBackupInternal calls endSession on the target.
-    delete backupOperationTarget;
-    backupOperationTarget = nullptr;
+  if (!backupOperationTarget) { // Check the local variable
+    QMessageBox::critical(this, tr("Backup Error"),
+                          tr("Failed to initialize backup target."));
+    updateLog("Error: Manual backup failed. Target initialization failed.");
+    return;
+  }
+
+  performBackupInternal(sourcePath, backupOperationTarget);
+
+  // Clean up the temporary target used for this backup operation
+  // performBackupInternal calls endSession on the target.
+  delete backupOperationTarget;
+  backupOperationTarget = nullptr;
 }
 
 void MainWindow::onGcsConnectButtonClicked() {
-    updateLog(tr("GCS 'Connect to Google Account' button clicked (OAuth process)."));
-    QString bucketName = gcsBucketNameLineEdit_->text();
-    QString accountId = gcsAccountIdentifierLineEdit_->text();
+  updateLog(
+      tr("GCS 'Connect to Google Account' button clicked (OAuth process)."));
+  QString bucketName = gcsBucketNameLineEdit_->text();
+  QString accountId = gcsAccountIdentifierLineEdit_->text();
 
-    if (bucketName.isEmpty() || accountId.isEmpty()) {
-        QMessageBox::warning(this, tr("GCS Configuration Error"),
-                             tr("GCS Bucket Name and Account Identifier must be provided before connecting for OAuth."));
-        updateLog(tr("GCS OAuth: Bucket Name or Account Identifier missing."));
-        return;
-    }
+  if (bucketName.isEmpty() || accountId.isEmpty()) {
+    QMessageBox::warning(this, tr("GCS Configuration Error"),
+                         tr("GCS Bucket Name and Account Identifier must be "
+                            "provided before connecting for OAuth."));
+    updateLog(tr("GCS OAuth: Bucket Name or Account Identifier missing."));
+    return;
+  }
 
-    std::map<std::string, std::string> gcsConfig;
-    gcsConfig["gcs_bucket_name"] = bucketName.toStdString();
-    gcsConfig["gcs_account_identifier"] = accountId.toStdString();
-    
-    GcsTarget tempGcsTargetForOAuth(gcsConfig, m_credentialManager.get()); // Create a temporary target for OAuth
+  std::map<std::string, std::string> gcsConfig;
+  gcsConfig["gcs_bucket_name"] = bucketName.toStdString();
+  gcsConfig["gcs_account_identifier"] = accountId.toStdString();
 
-    gcsAuthStatusLabel_->setText(tr("Status: Authenticating..."));
-    updateLog(QString("GCS OAuth: Attempting authentication for account '%1' (bucket '%2' context for token).").arg(accountId, bucketName));
+  GcsTarget tempGcsTargetForOAuth(
+      gcsConfig,
+      m_credentialManager.get()); // Create a temporary target for OAuth
 
-    if (tempGcsTargetForOAuth.initiateOAuthAndStoreToken()) { // Use the temporary target
-        gcsAuthStatusLabel_->setText(tr("Status: Authentication Successful for %1").arg(accountId));
-        updateLog(QString("GCS OAuth: Authentication successful for account '%1'.").arg(accountId));
+  gcsAuthStatusLabel_->setText(tr("Status: Authenticating..."));
+  updateLog(QString("GCS OAuth: Attempting authentication for account '%1' "
+                    "(bucket '%2' context for token).")
+                .arg(accountId, bucketName));
 
-        QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
-        settings.beginGroup("GCS");
-        settings.setValue("gcs_last_authenticated_account", accountId);
-        settings.endGroup();
-        updateLog(QString("GCS OAuth: Stored '%1' as last authenticated account.").arg(accountId));
+  if (tempGcsTargetForOAuth
+          .initiateOAuthAndStoreToken()) { // Use the temporary target
+    gcsAuthStatusLabel_->setText(
+        tr("Status: Authentication Successful for %1").arg(accountId));
+    updateLog(QString("GCS OAuth: Authentication successful for account '%1'.")
+                  .arg(accountId));
 
-        // IMPORTANT: DO NOT automatically connect for listing or browseRemotePath here.
-        // User must click the new gcsConnectToggleButton_ for that.
-        // Also, DO NOT change gcsConnectToggleButton_ text here.
+    QSettings settings(QCoreApplication::organizationName(),
+                       QCoreApplication::applicationName());
+    settings.beginGroup("GCS");
+    settings.setValue("gcs_last_authenticated_account", accountId);
+    settings.endGroup();
+    updateLog(QString("GCS OAuth: Stored '%1' as last authenticated account.")
+                  .arg(accountId));
 
-    } else {
-        gcsAuthStatusLabel_->setText(tr("Status: Authentication Failed. Check logs."));
-        QString gcsError = QString::fromStdString(tempGcsTargetForOAuth.getLastError());
-        updateLog(QString("GCS OAuth: Authentication failed for account '%1'. Error: %2")
-                      .arg(accountId, gcsError));
-        QMessageBox::critical(this, tr("GCS Authentication Failed"),
-                              tr("Could not authenticate with Google Cloud Storage for account '%1'. Error: %2")
+    // IMPORTANT: DO NOT automatically connect for listing or browseRemotePath
+    // here. User must click the new gcsConnectToggleButton_ for that. Also, DO
+    // NOT change gcsConnectToggleButton_ text here.
+
+  } else {
+    gcsAuthStatusLabel_->setText(
+        tr("Status: Authentication Failed. Check logs."));
+    QString gcsError =
+        QString::fromStdString(tempGcsTargetForOAuth.getLastError());
+    updateLog(
+        QString("GCS OAuth: Authentication failed for account '%1'. Error: %2")
+            .arg(accountId, gcsError));
+    QMessageBox::critical(this, tr("GCS Authentication Failed"),
+                          tr("Could not authenticate with Google Cloud Storage "
+                             "for account '%1'. Error: %2")
                               .arg(accountId, gcsError));
-        
-        // Reset UI related to listing, as it cannot proceed if OAuth fails
-        if (gcsConnectToggleButton_) { // Ensure button exists
-            gcsConnectToggleButton_->setText(tr("Connect"));
-        }
-        if (fileTableWidget_) { // Ensure table exists
-            fileTableWidget_->setRowCount(0);
-        }
-        currentRemotePath_ = "/";
-        if (currentPathLabel_) { // Ensure label exists
-            currentPathLabel_->setText(tr("Path: /"));
-        }
-        // QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
-        // settings.remove("GCS/gcs_last_authenticated_account"); 
+
+    // Reset UI related to listing, as it cannot proceed if OAuth fails
+    if (gcsConnectToggleButton_) { // Ensure button exists
+      gcsConnectToggleButton_->setText(tr("Connect"));
     }
-    // tempGcsTargetForOAuth goes out of scope here.
-    // The main gcsTarget_ (for listing) is managed by onGcsConnectToggleClicked.
+    if (fileTableWidget_) { // Ensure table exists
+      fileTableWidget_->setRowCount(0);
+    }
+    currentRemotePath_ = "/";
+    if (currentPathLabel_) { // Ensure label exists
+      currentPathLabel_->setText(tr("Path: /"));
+    }
+    // QSettings settings(QCoreApplication::organizationName(),
+    // QCoreApplication::applicationName());
+    // settings.remove("GCS/gcs_last_authenticated_account");
+  }
+  // tempGcsTargetForOAuth goes out of scope here.
+  // The main gcsTarget_ (for listing) is managed by onGcsConnectToggleClicked.
 }
 
-void MainWindow::onSftpConnectToggleClicked()
-{
-    if (sftpTarget_) { // Connected for listing -> Disconnect
-        updateLog(tr("SFTP 'Disconnect' (viewer) button clicked. Closing viewer session."));
-        sftpTarget_->endSession();
-        delete sftpTarget_;
-        sftpTarget_ = nullptr;
-        if (fileTableWidget_) { // Check if table exists
-            fileTableWidget_->setRowCount(0);
-        }
-        currentRemotePath_ = "/";
-        if (currentPathLabel_) { 
-            currentPathLabel_->setText(tr("Path: /"));
-        }
-        if (sftpConnectToggleButton_) { // Check if button exists
-            sftpConnectToggleButton_->setText(tr("Connect"));
-        }
-        updateLog(tr("SFTP viewer session closed.")); // Specific log message
-        return;
-    }
-
-    // Not connected for listing -> Connect
-    updateLog(tr("SFTP 'Connect' (viewer) button clicked. Attempting to open viewer session."));
-    std::map<std::string, std::string> cfg{
-        {"host", sftpHostLineEdit_->text().toStdString()},
-        {"port", sftpPortLineEdit_->text().toStdString()},
-        {"username", sftpUsernameLineEdit_->text().toStdString()},
-        {"remoteBasePath", sftpRemotePathLineEdit_->text().toStdString()}
-        // Password handling relies on SftpTarget's constructor/CredentialManager
-    };
-
-    if (cfg["host"].empty() || cfg["username"].empty()) {
-        QMessageBox::warning(this, tr("SFTP Configuration"), tr("SFTP Host and Username are required to connect for listing."));
-        updateLog(tr("SFTP viewer connection failed: Host or Username empty."));
-        // Ensure UI is in a consistent disconnected state (button text might already be "Connect")
-        if (sftpConnectToggleButton_) { sftpConnectToggleButton_->setText(tr("Connect")); }
-        if (fileTableWidget_) { fileTableWidget_->setRowCount(0); }
-        currentRemotePath_ = "/";
-        if (currentPathLabel_) { currentPathLabel_->setText(tr("Path: /")); }
-        return;
-    }
-
-    // Ensure this sftpTarget_ is exclusively for the viewer.
-    // If any old instance exists (should not happen if logic is correct), delete it.
-    // delete sftpTarget_; // Not strictly needed here if logic elsewhere is perfect, but safe.
-    // sftpTarget_ = nullptr; //
-    
-    sftpTarget_ = new SftpTarget(cfg); // MainWindow::sftpTarget_ is for the viewer
-    if (!sftpTarget_->beginSession()) {
-        QString err_msg = QString::fromStdString(sftpTarget_->getLastError()); // Get error before deleting target
-        QMessageBox::critical(this, tr("SFTP Error"), tr("SFTP viewer connection failed: %1").arg(err_msg.isEmpty() ? tr("Unknown error") : err_msg));
-        updateLog(tr("SFTP viewer connection failed: %1").arg(err_msg.isEmpty() ? tr("Unknown error") : err_msg));
-        delete sftpTarget_;
-        sftpTarget_ = nullptr;
-        // Ensure UI is in a consistent disconnected state
-        if (sftpConnectToggleButton_) { sftpConnectToggleButton_->setText(tr("Connect")); }
-        if (fileTableWidget_) { fileTableWidget_->setRowCount(0); }
-        currentRemotePath_ = "/";
-        if (currentPathLabel_) { currentPathLabel_->setText(tr("Path: /")); }
-        return;
-    }
-
-    if (sftpConnectToggleButton_) {
-        sftpConnectToggleButton_->setText(tr("Disconnect"));
-    }
-    currentRemotePath_ = "/"; 
-    // browseRemotePath will update currentPathLabel_
-    browseRemotePath(currentRemotePath_); 
-    updateLog(tr("SFTP viewer session opened.")); // Specific log message
-}
-
-void MainWindow::onGcsConnectToggleClicked()
-{
-    if (gcsTarget_) { // Connected for listing -> Disconnect
-        updateLog(tr("GCS 'Disconnect' button clicked. Closing session for listing."));
-        // We don't call endSession() if GCS target is used for active backup,
-        // but for listing, it's okay. However, GcsTarget::endSession might not do much
-        // if it's just a flag. The main thing is to delete the target for listing.
-        // Let's assume GcsTarget destructor or endSession handles any necessary cleanup.
-        gcsTarget_->endSession(); // Call directly
-        delete gcsTarget_;
-        gcsTarget_ = nullptr;
-        fileTableWidget_->setRowCount(0);
-        currentRemotePath_ = "/";
-        if (currentPathLabel_) {
-            currentPathLabel_->setText(tr("Path: /"));
-        }
-        gcsConnectToggleButton_->setText(tr("Connect"));
-        updateLog(tr("GCS session closed for listing. OAuth status is separate."));
-        // gcsAuthStatusLabel_ should NOT be changed here.
-        return;
-    }
-
-    // Not connected for listing -> Connect
-    updateLog(tr("GCS 'Connect' button clicked. Attempting to open session for listing."));
-
-    QString accountIdFromUI = gcsAccountIdentifierLineEdit_->text();
-    QString bucketNameFromUI = gcsBucketNameLineEdit_->text();
-
-    if (accountIdFromUI.isEmpty() || bucketNameFromUI.isEmpty()) {
-        QMessageBox::warning(this, tr("GCS Configuration"),
-                             tr("GCS Account Identifier and Bucket Name are required to connect for listing."));
-        updateLog(tr("GCS connection for listing failed: Account ID or Bucket Name empty."));
-        // Ensure UI is consistent
-        gcsConnectToggleButton_->setText(tr("Connect"));
-        fileTableWidget_->setRowCount(0);
-        currentRemotePath_ = "/";
-        if (currentPathLabel_) {
-            currentPathLabel_->setText(tr("Path: /"));
-        }
-        return;
-    }
-
-    // Check if OAuth has been done for this account
-    QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
-    QString lastAuthAccount = settings.value("GCS/gcs_last_authenticated_account").toString();
-    // A more robust check might involve GcsTarget itself having a method to check current auth status
-    // or MainWindow having a flag like `m_gcsOAuthSuccessfulForCurrentUser`
-    if (lastAuthAccount != accountIdFromUI) {
-        QMessageBox::warning(this, tr("GCS Authentication Required"),
-                             tr("Please use the 'Connect to Google Account' button to authenticate for account '%1' before attempting to list files.")
-                             .arg(accountIdFromUI));
-        updateLog(tr("GCS connection for listing aborted: Account '%1' not authenticated via 'Connect to Google Account' button, or does not match last authenticated user ('%2').")
-                      .arg(accountIdFromUI, lastAuthAccount));
-        // Ensure UI is consistent
-        gcsConnectToggleButton_->setText(tr("Connect"));
-        fileTableWidget_->setRowCount(0);
-        currentRemotePath_ = "/";
-        if (currentPathLabel_) {
-            currentPathLabel_->setText(tr("Path: /"));
-        }
-        return;
-    }
-    
-    // Check if token is still valid (GcsTarget might do this in beginSession)
-    // For now, we assume if lastAuthAccount matches, we can proceed.
-    // GcsTarget::beginSession() should fail if token is invalid/expired.
-
-    std::map<std::string, std::string> gcsConfig;
-    gcsConfig["gcs_bucket_name"] = bucketNameFromUI.toStdString();
-    gcsConfig["gcs_account_identifier"] = accountIdFromUI.toStdString();
-    // gcs_object_prefix for listing is implicitly handled by browseRemotePath starting at "/" relative to bucket root.
-
-    // Ensure no previous gcsTarget_ instance is active from other operations (e.g. backup)
-    // This toggle button should manage its own gcsTarget_ instance for listing.
-    // If a backup is running with gcsTarget_, this could interfere.
-    // For simplicity now, we assume this gcsTarget_ is primarily for listing.
-    // A more advanced setup might use separate target instances or a ref-counted session.
-    delete gcsTarget_; 
-    gcsTarget_ = new GcsTarget(gcsConfig, m_credentialManager.get());
-
-    if (!gcsTarget_->beginSession()) { // beginSession should verify token and connectivity
-        QString err = tr("GCS Connect for listing failed: %1")
-                      .arg(QString::fromStdString(gcsTarget_->getLastError()));
-        QMessageBox::critical(this, tr("GCS Error"), err);
-        updateLog(err);
-        delete gcsTarget_;
-        gcsTarget_ = nullptr;
-        // Ensure UI is consistent
-        gcsConnectToggleButton_->setText(tr("Connect"));
-        fileTableWidget_->setRowCount(0);
-        currentRemotePath_ = "/";
-        if (currentPathLabel_) {
-            currentPathLabel_->setText(tr("Path: /"));
-        }
-        // Potentially update gcsAuthStatusLabel_ if error indicates auth failure,
-        // but the plan says this button doesn't directly change it.
-        // However, if beginSession fails due to auth, the user should know.
-        // Perhaps GcsTarget::getLastError() can distinguish auth errors.
-        // For now, keeping gcsAuthStatusLabel_ unchanged by this button directly.
-        return;
-    }
-
-    gcsConnectToggleButton_->setText(tr("Disconnect"));
-    currentRemotePath_ = "/"; // Set before browse
-    if (currentPathLabel_) {
-        currentPathLabel_->setText(tr("Path: /"));
-    }
-    browseRemotePath(currentRemotePath_);
-    updateLog(tr("GCS session opened successfully for listing. Root directory displayed for bucket '%1'.")
-                  .arg(bucketNameFromUI));
-}
-
-void MainWindow::onGcsTestConnectionClicked() {
-    updateLog("GCS Test Connection button clicked.");
-    QString bucketName = gcsBucketNameLineEdit_->text();
-    QString accountId = gcsAccountIdentifierLineEdit_->text();
-
-    if (bucketName.isEmpty() || accountId.isEmpty()) {
-        QMessageBox::warning(this, tr("GCS Configuration Error"),
-                             tr("GCS Bucket Name and Account Identifier must be provided before testing connection."));
-        updateLog("GCS Test Connection: Bucket Name or Account Identifier missing.");
-        return;
-    }
-
-    std::map<std::string, std::string> gcsConfig;
-    gcsConfig["gcs_bucket_name"] = bucketName.toStdString();
-    gcsConfig["gcs_account_identifier"] = accountId.toStdString();
-
-    delete gcsTarget_;
-    gcsTarget_ = new GcsTarget(gcsConfig, m_credentialManager.get());
-
-    gcsAuthStatusLabel_->setText(tr("Status: Testing Connection..."));
-    updateLog(QString("GCS Test Connection: Attempting for account '%1' with bucket '%2'.").arg(accountId, bucketName));
-
-    std::string testErrorMsg;
-    if (gcsTarget_->testConnection(testErrorMsg)) {
-        QMessageBox::information(this, tr("GCS Connection Test"), tr("Connection Successful!"));
-        updateLog(QString("GCS Test Connection: Successful for account '%1'.").arg(accountId));
-
-        QString lastAuthAccount = QSettings().value("GCS/gcs_last_authenticated_account").toString();
-        if (!lastAuthAccount.isEmpty() && lastAuthAccount == accountId) {
-            gcsAuthStatusLabel_->setText(tr("Status: Authenticated as %1").arg(accountId));
-        } else {
-            // If test passed but not explicitly "Connected" via button, or token expired and test used a new one implicitly
-            gcsAuthStatusLabel_->setText(tr("Status: Connection test passed."));
-        }
-    } else {
-        QMessageBox::warning(this, tr("GCS Connection Test"), tr("Connection Failed: %1").arg(QString::fromStdString(testErrorMsg)));
-        updateLog(QString("GCS Test Connection: Failed for account '%1'. Error: %2").arg(accountId, QString::fromStdString(testErrorMsg)));
-        if (testErrorMsg.find("OAuth") != std::string::npos || testErrorMsg.find("token") != std::string::npos ||
-            testErrorMsg.find("permission") != std::string::npos || testErrorMsg.find("denied") != std::string::npos ||
-            testErrorMsg.find("authenticate") != std::string::npos) { // Added generic auth term
-            gcsAuthStatusLabel_->setText(tr("Status: Auth/Permission issue during test."));
-        } else {
-            gcsAuthStatusLabel_->setText(tr("Status: Connection test failed."));
-        }
-    }
-
-    delete gcsTarget_;
-    gcsTarget_ = nullptr;
-}
-
-void MainWindow::performBackupInternal(const QString& sourcePath, IStorageTarget* target) {
-    if (!target) {
-        updateLog("Error: performBackupInternal called with null target.");
-        QMessageBox::critical(this, tr("Backup Failed"), tr("Internal error: Backup target not specified."));
-        return;
-    }
-    updateLog(QString("Performing backup using active target: Source: %1").arg(sourcePath));
-
-    std::filesystem::path fsSourcePath(sourcePath.toStdString());
-
-    QFileInfo initialSourceInfo(QString::fromStdString(fsSourcePath.string()));
-    QString baseDirForLambda = initialSourceInfo.absolutePath();
-
-    if (!std::filesystem::is_directory(fsSourcePath)) {
-         updateLog(QString("Error: Source path '%1' is not a directory.").arg(sourcePath));
-         QMessageBox::critical(this, tr("Backup Failed"), tr("Source path is not a directory."));
-         return;
-    }
-    
-    if (!target->beginSession()) {
-        std::string specificError;
-        GcsTarget* currentGcsTarget = dynamic_cast<GcsTarget*>(target);
-        if (currentGcsTarget) {
-            specificError = currentGcsTarget->getLastError();
-        }
-        QString errorDetails = QString::fromStdString(specificError);
-        if (errorDetails.isEmpty()) errorDetails = tr("Check target logs for more information.");
-
-        updateLog(QString("Error: Could not begin backup session. Target error: %1").arg(errorDetails));
-        QMessageBox::critical(this, tr("Backup Failed"), tr("Could not begin backup session. Details: %1").arg(errorDetails));
-        return;
-    }
-
-    if (!std::filesystem::exists(fsSourcePath)) {
-        updateLog(QString("Error: Source directory '%1' does not exist.").arg(sourcePath));
-        target->endSession();
-        QMessageBox::critical(this, tr("Backup Failed"), tr("Source directory not found."));
-        return;
-    }
-    
-    updateLog(QString("Starting recursive scan of source directory: %1").arg(sourcePath));
-    bool all_ok = true;
-    int files_processed_count = 0;
-
-    std::function<void(const std::filesystem::path&)> recursiveCopy;
-    recursiveCopy = 
-       [&](const std::filesystem::path& currentPathInSource) {
-       try {
-           for (const auto& entry : std::filesystem::directory_iterator(currentPathInSource)) {
-               std::filesystem::path fullEntryPath = entry.path();
-               QString qFullEntryPath_new = QString::fromStdString(fullEntryPath.string());
-               std::string relativePathStr = qFullEntryPath_new.mid(baseDirForLambda.length() + (baseDirForLambda == "/" ? 0 : 1)).toStdString();
-
-               if (entry.is_directory()) {
-                   updateLog(QString("Scanning subdirectory: %1").arg(QString::fromStdString(relativePathStr)));
-                   recursiveCopy(fullEntryPath); 
-               } else if (entry.is_regular_file()) {
-                   ++files_processed_count;
-
-                   // Fabrique un FileMetadata minimal
-                   FileMetadata meta;
-                   meta.name          = relativePathStr;
-                   meta.size          = entry.file_size();
-                   auto ftime = entry.last_write_time();
-                   auto sctp  = std::chrono::time_point_cast<
-                                   std::chrono::system_clock::duration>(
-                                   ftime - decltype(ftime)::clock::now()
-                                   + std::chrono::system_clock::now());
-                   meta.modificationTime = sctp;
-
-                   if (target->sendFile(fullEntryPath.string(), meta)) {
-                       updateLog(QString("Backed up: %1").arg(QString::fromStdString(relativePathStr)));
-                   } else {
-                       all_ok = false; // Set all_ok to false on sendFile failure
-
-                       std::string err_msg;
-                       // Attempt to get specific error message using dynamic_cast
-                       if (auto sftpTarget = dynamic_cast<SftpTarget*>(target)) {
-                           err_msg = sftpTarget->getLastError();
-                       } else if (auto gcsTarget = dynamic_cast<GcsTarget*>(target)) {
-                           err_msg = gcsTarget->getLastError();
-                       } else if (auto localTarget = dynamic_cast<LocalTarget*>(target)) {
-                           // Assuming LocalTarget might also have getLastError() or a similar mechanism
-                           // If LocalTarget does not have getLastError(), this will need adjustment
-                           // For now, let's assume it might return a generic error if getLastError() isn't present.
-                           // err_msg = localTarget->getLastError(); // Uncomment if LocalTarget has this
-                           if (err_msg.empty()) err_msg = "File operation failed with LocalTarget.";
-                       } else {
-                           err_msg = "Unknown target type or error during sendFile.";
-                       }
-                       if (err_msg.empty()) { // Fallback if getLastError() returned empty
-                           err_msg = "target->sendFile() failed with no specific error message provided by the target.";
-                       }
-
-                       updateLog(QString("Error backing up: %1. Error: %2")
-                                     .arg(QString::fromStdString(relativePathStr))
-                                     .arg(QString::fromStdString(err_msg)));
-
-                       QMessageBox::critical(this, "Backup Error",
-                                             QString("Failed to back up: %1\nError: %2")
-                                                 .arg(QString::fromStdString(relativePathStr))
-                                                 .arg(QString::fromStdString(err_msg)));
-                       return; // Stop backup if one file fails (as per original logic)
-                   }
-               }
-           }
-       } catch (const std::filesystem::filesystem_error& e) {
-            updateLog(QString("Error accessing path %1: %2").arg(QString::fromStdString(currentPathInSource.string()), QString::fromStdString(e.what())));
-            all_ok = false; // This is already correct
-       }
-    };
-
-    recursiveCopy(fsSourcePath); 
-
-    if (!target->endSession()) {
-        all_ok = false; // Ensure all_ok is set if endSession fails
-
-        std::string specificError;
-        // Retrieve error from specific target type for endSession failure
-        if (auto sftpTarget = dynamic_cast<SftpTarget*>(target)) {
-            specificError = sftpTarget->getLastError();
-        } else if (auto gcsTarget = dynamic_cast<GcsTarget*>(target)) {
-            specificError = gcsTarget->getLastError();
-        } else if (auto localTarget = dynamic_cast<LocalTarget*>(target)) {
-            // Assuming LocalTarget might also have getLastError()
-            // specificError = localTarget->getLastError(); // Uncomment if LocalTarget has this
-             if (specificError.empty()) specificError = "Failed to end session with LocalTarget.";
-        } else {
-            specificError = "Unknown target type or error during endSession.";
-        }
-        if (specificError.empty()) {
-             specificError = "target->endSession() failed with no specific error message provided by the target.";
-        }
-
-        QString errorDetails = QString::fromStdString(specificError);
-        updateLog(QString("Error: Could not properly end backup session with target. Target error: %1").arg(errorDetails));
-        // No QMessageBox here as the final summary will indicate errors.
-    }
-
-    if (all_ok) {
-        if (files_processed_count == 0) {
-            updateLog(QString("Backup completed. No files were found to back up in '%1'.").arg(sourcePath));
-            QMessageBox::information(this, tr("Backup Complete"), tr("Backup completed. No files were found in the source directory."));
-        } else {
-            updateLog(QString("Backup process completed successfully. %1 files processed.").arg(files_processed_count));
-            QMessageBox::information(this, tr("Backup Complete"), tr("Backup completed successfully."));
-        }
-    } else {
-        updateLog("Backup process completed with some errors. Please check the log.");
-        QMessageBox::warning(this, tr("Backup Complete (with errors)"), tr("Backup completed with some errors. Please check the log."));
-    }
-}
-
-
-void MainWindow::updateLog(const QString& message) {
-    QString timestamp = QTime::currentTime().toString("HH:mm:ss");
-    logDisplay_->append(QString("[%1] %2").arg(timestamp, message));
-    qDebug() << "[GUI Log]" << message; 
-}
-
-void MainWindow::onTaskChanged() {
-    sourceDirEdit_->setText(scheduler_->sourcePath());
-    
-    if (scheduler_->isGcsMode()) {
-        backupModeComboBox_->setCurrentText(tr("Google Cloud Storage"));
-        gcsBucketNameLineEdit_->setText(scheduler_->gcsBucketName());
-        gcsAccountIdentifierLineEdit_->setText(scheduler_->gcsAccountIdentifier());
-    } else if (scheduler_->isSftpMode()) {
-        backupModeComboBox_->setCurrentText(tr("SFTP Backup"));
-    } else {
-        backupModeComboBox_->setCurrentText(tr("Local Backup"));
-        destinationDirEdit_->setText(scheduler_->destinationPath());
-    }
-    
-    timeListWidget_->clear();
-    QList<QTime> stimes = scheduler_->scheduledTimes();
-    if (!stimes.isEmpty()) {
-        for (const QTime& t : stimes) {
-            timeListWidget_->addItem(t.toString("HH:mm"));
-        }
-        backupTimeEdit_->setTime(stimes.first());
-    } else {
-        backupTimeEdit_->setTime(QTime(23, 0));
-    }
-    onBackupModeChanged(backupModeComboBox_->currentIndex());
-    updateLog("Task details updated in UI from Scheduler state.");
-}
-
-void MainWindow::onBackupModeChanged(int index) {
-    QString currentModeText = backupModeComboBox_->itemText(index);
-    bool localSelected = (currentModeText == tr("Local Backup"));
-    bool sftpSelected = (currentModeText == tr("SFTP Backup"));
-    bool gcsSelected = (currentModeText == tr("Google Cloud Storage"));
-
-    updateLog(QString("Backup mode changing. Selected: %1").arg(currentModeText));
-
-    // End active SFTP listing session if switching away from SFTP mode
-    if (!sftpSelected && sftpTarget_) {
-        updateLog(tr("Switched away from SFTP mode. Closing active SFTP listing session."));
-        sftpTarget_->endSession();
-        delete sftpTarget_;
-        sftpTarget_ = nullptr;
-        if (sftpConnectToggleButton_) { // Ensure button exists
-            sftpConnectToggleButton_->setText(tr("Connect"));
-        }
-    }
-
-    // End active GCS listing session if switching away from GCS mode
-    if (!gcsSelected && gcsTarget_) {
-        updateLog(tr("Switched away from GCS mode. Closing active GCS listing session."));
-        gcsTarget_->endSession(); // Call directly
-        delete gcsTarget_;
-        gcsTarget_ = nullptr;
-        if (gcsConnectToggleButton_) { // Ensure button exists
-            gcsConnectToggleButton_->setText(tr("Connect"));
-        }
-        // Note: gcsAuthStatusLabel_ is NOT changed here. OAuth state persists.
-    }
-
-    // Always reset file viewer UI elements on any mode change
-    if (fileTableWidget_) {
-        fileTableWidget_->setRowCount(0);
+void MainWindow::onSftpConnectToggleClicked() {
+  if (sftpTarget_) { // Connected for listing -> Disconnect
+    updateLog(tr(
+        "SFTP 'Disconnect' (viewer) button clicked. Closing viewer session."));
+    sftpTarget_->endSession();
+    delete sftpTarget_;
+    sftpTarget_ = nullptr;
+    if (fileTableWidget_) { // Check if table exists
+      fileTableWidget_->setRowCount(0);
     }
     currentRemotePath_ = "/";
     if (currentPathLabel_) {
-        currentPathLabel_->setText(tr("Path: /"));
+      currentPathLabel_->setText(tr("Path: /"));
+    }
+    if (sftpConnectToggleButton_) { // Check if button exists
+      sftpConnectToggleButton_->setText(tr("Connect"));
+    }
+    updateLog(tr("SFTP viewer session closed.")); // Specific log message
+    return;
+  }
+
+  // Not connected for listing -> Connect
+  updateLog(tr("SFTP 'Connect' (viewer) button clicked. Attempting to open "
+               "viewer session."));
+  std::map<std::string, std::string> cfg{
+      {"host", sftpHostLineEdit_->text().toStdString()},
+      {"port", sftpPortLineEdit_->text().toStdString()},
+      {"username", sftpUsernameLineEdit_->text().toStdString()},
+      {"remoteBasePath", sftpRemotePathLineEdit_->text().toStdString()}
+      // Password handling relies on SftpTarget's constructor/CredentialManager
+  };
+
+  if (cfg["host"].empty() || cfg["username"].empty()) {
+    QMessageBox::warning(
+        this, tr("SFTP Configuration"),
+        tr("SFTP Host and Username are required to connect for listing."));
+    updateLog(tr("SFTP viewer connection failed: Host or Username empty."));
+    // Ensure UI is in a consistent disconnected state (button text might
+    // already be "Connect")
+    if (sftpConnectToggleButton_) {
+      sftpConnectToggleButton_->setText(tr("Connect"));
+    }
+    if (fileTableWidget_) {
+      fileTableWidget_->setRowCount(0);
+    }
+    currentRemotePath_ = "/";
+    if (currentPathLabel_) {
+      currentPathLabel_->setText(tr("Path: /"));
+    }
+    return;
+  }
+
+  // Ensure this sftpTarget_ is exclusively for the viewer.
+  // If any old instance exists (should not happen if logic is correct), delete
+  // it. delete sftpTarget_; // Not strictly needed here if logic elsewhere is
+  // perfect, but safe. sftpTarget_ = nullptr; //
+
+  sftpTarget_ =
+      new SftpTarget(cfg); // MainWindow::sftpTarget_ is for the viewer
+  if (!sftpTarget_->beginSession()) {
+    QString err_msg = QString::fromStdString(
+        sftpTarget_->getLastError()); // Get error before deleting target
+    QMessageBox::critical(
+        this, tr("SFTP Error"),
+        tr("SFTP viewer connection failed: %1")
+            .arg(err_msg.isEmpty() ? tr("Unknown error") : err_msg));
+    updateLog(tr("SFTP viewer connection failed: %1")
+                  .arg(err_msg.isEmpty() ? tr("Unknown error") : err_msg));
+    delete sftpTarget_;
+    sftpTarget_ = nullptr;
+    // Ensure UI is in a consistent disconnected state
+    if (sftpConnectToggleButton_) {
+      sftpConnectToggleButton_->setText(tr("Connect"));
+    }
+    if (fileTableWidget_) {
+      fileTableWidget_->setRowCount(0);
+    }
+    currentRemotePath_ = "/";
+    if (currentPathLabel_) {
+      currentPathLabel_->setText(tr("Path: /"));
+    }
+    return;
+  }
+
+  if (sftpConnectToggleButton_) {
+    sftpConnectToggleButton_->setText(tr("Disconnect"));
+  }
+  currentRemotePath_ = "/";
+  // browseRemotePath will update currentPathLabel_
+  browseRemotePath(currentRemotePath_);
+  updateLog(tr("SFTP viewer session opened.")); // Specific log message
+}
+
+void MainWindow::onGcsConnectToggleClicked() {
+  if (gcsTarget_) { // Connected for listing -> Disconnect
+    updateLog(
+        tr("GCS 'Disconnect' button clicked. Closing session for listing."));
+    // We don't call endSession() if GCS target is used for active backup,
+    // but for listing, it's okay. However, GcsTarget::endSession might not do
+    // much if it's just a flag. The main thing is to delete the target for
+    // listing. Let's assume GcsTarget destructor or endSession handles any
+    // necessary cleanup.
+    gcsTarget_->endSession(); // Call directly
+    delete gcsTarget_;
+    gcsTarget_ = nullptr;
+    fileTableWidget_->setRowCount(0);
+    currentRemotePath_ = "/";
+    if (currentPathLabel_) {
+      currentPathLabel_->setText(tr("Path: /"));
+    }
+    gcsConnectToggleButton_->setText(tr("Connect"));
+    updateLog(tr("GCS session closed for listing. OAuth status is separate."));
+    // gcsAuthStatusLabel_ should NOT be changed here.
+    return;
+  }
+
+  // Not connected for listing -> Connect
+  updateLog(tr(
+      "GCS 'Connect' button clicked. Attempting to open session for listing."));
+
+  QString accountIdFromUI = gcsAccountIdentifierLineEdit_->text();
+  QString bucketNameFromUI = gcsBucketNameLineEdit_->text();
+
+  if (accountIdFromUI.isEmpty() || bucketNameFromUI.isEmpty()) {
+    QMessageBox::warning(this, tr("GCS Configuration"),
+                         tr("GCS Account Identifier and Bucket Name are "
+                            "required to connect for listing."));
+    updateLog(tr(
+        "GCS connection for listing failed: Account ID or Bucket Name empty."));
+    // Ensure UI is consistent
+    gcsConnectToggleButton_->setText(tr("Connect"));
+    fileTableWidget_->setRowCount(0);
+    currentRemotePath_ = "/";
+    if (currentPathLabel_) {
+      currentPathLabel_->setText(tr("Path: /"));
+    }
+    return;
+  }
+
+  // Check if OAuth has been done for this account
+  QSettings settings(QCoreApplication::organizationName(),
+                     QCoreApplication::applicationName());
+  QString lastAuthAccount =
+      settings.value("GCS/gcs_last_authenticated_account").toString();
+  // A more robust check might involve GcsTarget itself having a method to check
+  // current auth status or MainWindow having a flag like
+  // `m_gcsOAuthSuccessfulForCurrentUser`
+  if (lastAuthAccount != accountIdFromUI) {
+    QMessageBox::warning(
+        this, tr("GCS Authentication Required"),
+        tr("Please use the 'Connect to Google Account' button to authenticate "
+           "for account '%1' before attempting to list files.")
+            .arg(accountIdFromUI));
+    updateLog(tr("GCS connection for listing aborted: Account '%1' not "
+                 "authenticated via 'Connect to Google Account' button, or "
+                 "does not match last authenticated user ('%2').")
+                  .arg(accountIdFromUI, lastAuthAccount));
+    // Ensure UI is consistent
+    gcsConnectToggleButton_->setText(tr("Connect"));
+    fileTableWidget_->setRowCount(0);
+    currentRemotePath_ = "/";
+    if (currentPathLabel_) {
+      currentPathLabel_->setText(tr("Path: /"));
+    }
+    return;
+  }
+
+  // Check if token is still valid (GcsTarget might do this in beginSession)
+  // For now, we assume if lastAuthAccount matches, we can proceed.
+  // GcsTarget::beginSession() should fail if token is invalid/expired.
+
+  std::map<std::string, std::string> gcsConfig;
+  gcsConfig["gcs_bucket_name"] = bucketNameFromUI.toStdString();
+  gcsConfig["gcs_account_identifier"] = accountIdFromUI.toStdString();
+  // gcs_object_prefix for listing is implicitly handled by browseRemotePath
+  // starting at "/" relative to bucket root.
+
+  // Ensure no previous gcsTarget_ instance is active from other operations
+  // (e.g. backup) This toggle button should manage its own gcsTarget_ instance
+  // for listing. If a backup is running with gcsTarget_, this could interfere.
+  // For simplicity now, we assume this gcsTarget_ is primarily for listing.
+  // A more advanced setup might use separate target instances or a ref-counted
+  // session.
+  delete gcsTarget_;
+  gcsTarget_ = new GcsTarget(gcsConfig, m_credentialManager.get());
+
+  if (!gcsTarget_->beginSession()) { // beginSession should verify token and
+                                     // connectivity
+    QString err = tr("GCS Connect for listing failed: %1")
+                      .arg(QString::fromStdString(gcsTarget_->getLastError()));
+    QMessageBox::critical(this, tr("GCS Error"), err);
+    updateLog(err);
+    delete gcsTarget_;
+    gcsTarget_ = nullptr;
+    // Ensure UI is consistent
+    gcsConnectToggleButton_->setText(tr("Connect"));
+    fileTableWidget_->setRowCount(0);
+    currentRemotePath_ = "/";
+    if (currentPathLabel_) {
+      currentPathLabel_->setText(tr("Path: /"));
+    }
+    // Potentially update gcsAuthStatusLabel_ if error indicates auth failure,
+    // but the plan says this button doesn't directly change it.
+    // However, if beginSession fails due to auth, the user should know.
+    // Perhaps GcsTarget::getLastError() can distinguish auth errors.
+    // For now, keeping gcsAuthStatusLabel_ unchanged by this button directly.
+    return;
+  }
+
+  gcsConnectToggleButton_->setText(tr("Disconnect"));
+  currentRemotePath_ = "/"; // Set before browse
+  if (currentPathLabel_) {
+    currentPathLabel_->setText(tr("Path: /"));
+  }
+  browseRemotePath(currentRemotePath_);
+  updateLog(tr("GCS session opened successfully for listing. Root directory "
+               "displayed for bucket '%1'.")
+                .arg(bucketNameFromUI));
+}
+
+void MainWindow::onGcsTestConnectionClicked() {
+  updateLog("GCS Test Connection button clicked.");
+  QString bucketName = gcsBucketNameLineEdit_->text();
+  QString accountId = gcsAccountIdentifierLineEdit_->text();
+
+  if (bucketName.isEmpty() || accountId.isEmpty()) {
+    QMessageBox::warning(this, tr("GCS Configuration Error"),
+                         tr("GCS Bucket Name and Account Identifier must be "
+                            "provided before testing connection."));
+    updateLog(
+        "GCS Test Connection: Bucket Name or Account Identifier missing.");
+    return;
+  }
+
+  std::map<std::string, std::string> gcsConfig;
+  gcsConfig["gcs_bucket_name"] = bucketName.toStdString();
+  gcsConfig["gcs_account_identifier"] = accountId.toStdString();
+
+  delete gcsTarget_;
+  gcsTarget_ = new GcsTarget(gcsConfig, m_credentialManager.get());
+
+  gcsAuthStatusLabel_->setText(tr("Status: Testing Connection..."));
+  updateLog(
+      QString(
+          "GCS Test Connection: Attempting for account '%1' with bucket '%2'.")
+          .arg(accountId, bucketName));
+
+  std::string testErrorMsg;
+  if (gcsTarget_->testConnection(testErrorMsg)) {
+    QMessageBox::information(this, tr("GCS Connection Test"),
+                             tr("Connection Successful!"));
+    updateLog(QString("GCS Test Connection: Successful for account '%1'.")
+                  .arg(accountId));
+
+    QString lastAuthAccount =
+        QSettings().value("GCS/gcs_last_authenticated_account").toString();
+    if (!lastAuthAccount.isEmpty() && lastAuthAccount == accountId) {
+      gcsAuthStatusLabel_->setText(
+          tr("Status: Authenticated as %1").arg(accountId));
+    } else {
+      // If test passed but not explicitly "Connected" via button, or token
+      // expired and test used a new one implicitly
+      gcsAuthStatusLabel_->setText(tr("Status: Connection test passed."));
+    }
+  } else {
+    QMessageBox::warning(
+        this, tr("GCS Connection Test"),
+        tr("Connection Failed: %1").arg(QString::fromStdString(testErrorMsg)));
+    updateLog(QString("GCS Test Connection: Failed for account '%1'. Error: %2")
+                  .arg(accountId, QString::fromStdString(testErrorMsg)));
+    if (testErrorMsg.find("OAuth") != std::string::npos ||
+        testErrorMsg.find("token") != std::string::npos ||
+        testErrorMsg.find("permission") != std::string::npos ||
+        testErrorMsg.find("denied") != std::string::npos ||
+        testErrorMsg.find("authenticate") !=
+            std::string::npos) { // Added generic auth term
+      gcsAuthStatusLabel_->setText(
+          tr("Status: Auth/Permission issue during test."));
+    } else {
+      gcsAuthStatusLabel_->setText(tr("Status: Connection test failed."));
+    }
+  }
+
+  delete gcsTarget_;
+  gcsTarget_ = nullptr;
+}
+
+void MainWindow::performBackupInternal(const QString &sourcePath,
+                                       IStorageTarget *target) {
+  if (!target) {
+    updateLog("Error: performBackupInternal called with null target.");
+    QMessageBox::critical(this, tr("Backup Failed"),
+                          tr("Internal error: Backup target not specified."));
+    return;
+  }
+  updateLog(QString("Performing backup using active target: Source: %1")
+                .arg(sourcePath));
+
+  std::filesystem::path fsSourcePath(sourcePath.toStdString());
+
+  QFileInfo initialSourceInfo(QString::fromStdString(fsSourcePath.string()));
+  QString baseDirForLambda = initialSourceInfo.absolutePath();
+
+  if (!std::filesystem::is_directory(fsSourcePath)) {
+    updateLog(
+        QString("Error: Source path '%1' is not a directory.").arg(sourcePath));
+    QMessageBox::critical(this, tr("Backup Failed"),
+                          tr("Source path is not a directory."));
+    return;
+  }
+
+  if (!target->beginSession()) {
+    std::string specificError;
+    GcsTarget *currentGcsTarget = dynamic_cast<GcsTarget *>(target);
+    if (currentGcsTarget) {
+      specificError = currentGcsTarget->getLastError();
+    }
+    QString errorDetails = QString::fromStdString(specificError);
+    if (errorDetails.isEmpty())
+      errorDetails = tr("Check target logs for more information.");
+
+    updateLog(QString("Error: Could not begin backup session. Target error: %1")
+                  .arg(errorDetails));
+    QMessageBox::critical(
+        this, tr("Backup Failed"),
+        tr("Could not begin backup session. Details: %1").arg(errorDetails));
+    return;
+  }
+
+  if (!std::filesystem::exists(fsSourcePath)) {
+    updateLog(QString("Error: Source directory '%1' does not exist.")
+                  .arg(sourcePath));
+    target->endSession();
+    QMessageBox::critical(this, tr("Backup Failed"),
+                          tr("Source directory not found."));
+    return;
+  }
+
+  updateLog(QString("Starting recursive scan of source directory: %1")
+                .arg(sourcePath));
+  bool all_ok = true;
+  int files_processed_count = 0;
+
+  std::function<void(const std::filesystem::path &)> recursiveCopy;
+  recursiveCopy = [&](const std::filesystem::path &currentPathInSource) {
+    try {
+      for (const auto &entry :
+           std::filesystem::directory_iterator(currentPathInSource)) {
+        std::filesystem::path fullEntryPath = entry.path();
+        QString qFullEntryPath_new =
+            QString::fromStdString(fullEntryPath.string());
+        std::string relativePathStr =
+            qFullEntryPath_new
+                .mid(baseDirForLambda.length() +
+                     (baseDirForLambda == "/" ? 0 : 1))
+                .toStdString();
+
+        if (entry.is_directory()) {
+          updateLog(QString("Scanning subdirectory: %1")
+                        .arg(QString::fromStdString(relativePathStr)));
+          recursiveCopy(fullEntryPath);
+        } else if (entry.is_regular_file()) {
+          ++files_processed_count;
+
+          // Fabrique un FileMetadata minimal
+          FileMetadata meta;
+          meta.name = relativePathStr;
+          meta.size = entry.file_size();
+          auto ftime = entry.last_write_time();
+          auto sctp =
+              std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+                  ftime - decltype(ftime)::clock::now() +
+                  std::chrono::system_clock::now());
+          meta.modificationTime = sctp;
+
+          if (target->sendFile(fullEntryPath.string(), meta)) {
+            updateLog(QString("Backed up: %1")
+                          .arg(QString::fromStdString(relativePathStr)));
+          } else {
+            all_ok = false; // Set all_ok to false on sendFile failure
+
+            std::string err_msg;
+            // Attempt to get specific error message using dynamic_cast
+            if (auto sftpTarget = dynamic_cast<SftpTarget *>(target)) {
+              err_msg = sftpTarget->getLastError();
+            } else if (auto gcsTarget = dynamic_cast<GcsTarget *>(target)) {
+              err_msg = gcsTarget->getLastError();
+            } else if (auto localTarget = dynamic_cast<LocalTarget *>(target)) {
+              // Assuming LocalTarget might also have getLastError() or a
+              // similar mechanism If LocalTarget does not have getLastError(),
+              // this will need adjustment For now, let's assume it might return
+              // a generic error if getLastError() isn't present. err_msg =
+              // localTarget->getLastError(); // Uncomment if LocalTarget has
+              // this
+              if (err_msg.empty())
+                err_msg = "File operation failed with LocalTarget.";
+            } else {
+              err_msg = "Unknown target type or error during sendFile.";
+            }
+            if (err_msg.empty()) { // Fallback if getLastError() returned empty
+              err_msg = "target->sendFile() failed with no specific error "
+                        "message provided by the target.";
+            }
+
+            updateLog(QString("Error backing up: %1. Error: %2")
+                          .arg(QString::fromStdString(relativePathStr))
+                          .arg(QString::fromStdString(err_msg)));
+
+            QMessageBox::critical(
+                this, "Backup Error",
+                QString("Failed to back up: %1\nError: %2")
+                    .arg(QString::fromStdString(relativePathStr))
+                    .arg(QString::fromStdString(err_msg)));
+            return; // Stop backup if one file fails (as per original logic)
+          }
+        }
+      }
+    } catch (const std::filesystem::filesystem_error &e) {
+      updateLog(QString("Error accessing path %1: %2")
+                    .arg(QString::fromStdString(currentPathInSource.string()),
+                         QString::fromStdString(e.what())));
+      all_ok = false; // This is already correct
+    }
+  };
+
+  recursiveCopy(fsSourcePath);
+
+  if (!target->endSession()) {
+    all_ok = false; // Ensure all_ok is set if endSession fails
+
+    std::string specificError;
+    // Retrieve error from specific target type for endSession failure
+    if (auto sftpTarget = dynamic_cast<SftpTarget *>(target)) {
+      specificError = sftpTarget->getLastError();
+    } else if (auto gcsTarget = dynamic_cast<GcsTarget *>(target)) {
+      specificError = gcsTarget->getLastError();
+    } else if (auto localTarget = dynamic_cast<LocalTarget *>(target)) {
+      // Assuming LocalTarget might also have getLastError()
+      // specificError = localTarget->getLastError(); // Uncomment if
+      // LocalTarget has this
+      if (specificError.empty())
+        specificError = "Failed to end session with LocalTarget.";
+    } else {
+      specificError = "Unknown target type or error during endSession.";
+    }
+    if (specificError.empty()) {
+      specificError = "target->endSession() failed with no specific error "
+                      "message provided by the target.";
     }
 
-    // Show/hide relevant group boxes
-    if (m_localDestinationGroupBox) m_localDestinationGroupBox->setVisible(localSelected);
-    if (sftpSettingsGroupBox_) sftpSettingsGroupBox_->setVisible(sftpSelected);
-    if (gcsSettingsGroupBox_) gcsSettingsGroupBox_->setVisible(gcsSelected);
+    QString errorDetails = QString::fromStdString(specificError);
+    updateLog(QString("Error: Could not properly end backup session with "
+                      "target. Target error: %1")
+                  .arg(errorDetails));
+    // No QMessageBox here as the final summary will indicate errors.
+  }
 
-    // Show/hide file viewer group box (only for remote modes)
-    bool remoteModeSelected = (sftpSelected || gcsSelected);
-    if (fileViewerDockWidget_) {
-        fileViewerDockWidget_->setVisible(remoteModeSelected);
+  if (all_ok) {
+    if (files_processed_count == 0) {
+      updateLog(
+          QString("Backup completed. No files were found to back up in '%1'.")
+              .arg(sourcePath));
+      QMessageBox::information(
+          this, tr("Backup Complete"),
+          tr("Backup completed. No files were found in the source directory."));
+    } else {
+      updateLog(
+          QString("Backup process completed successfully. %1 files processed.")
+              .arg(files_processed_count));
+      QMessageBox::information(this, tr("Backup Complete"),
+                               tr("Backup completed successfully."));
     }
+  } else {
+    updateLog(
+        "Backup process completed with some errors. Please check the log.");
+    QMessageBox::warning(
+        this, tr("Backup Complete (with errors)"),
+        tr("Backup completed with some errors. Please check the log."));
+  }
+}
 
-    // IMPORTANT: Automatic connection and browsing logic has been removed.
-    // The user now explicitly clicks the "Connect" button for SFTP/GCS listing.
+void MainWindow::updateLog(const QString &message) {
+  QString timestamp = QTime::currentTime().toString("HH:mm:ss");
+  logDisplay_->append(QString("[%1] %2").arg(timestamp, message));
+  qDebug() << "[GUI Log]" << message;
+}
 
-    updateLog(QString("Backup mode changed to: %1. UI adjusted. File viewer visible: %2.")
-                  .arg(currentModeText)
-                  .arg(remoteModeSelected ? "Yes" : "No"));
+void MainWindow::onTaskChanged() {
+  sourceDirEdit_->setText(scheduler_->sourcePath());
+
+  if (scheduler_->isGcsMode()) {
+    backupModeComboBox_->setCurrentText(tr("Google Cloud Storage"));
+    gcsBucketNameLineEdit_->setText(scheduler_->gcsBucketName());
+    gcsAccountIdentifierLineEdit_->setText(scheduler_->gcsAccountIdentifier());
+  } else if (scheduler_->isSftpMode()) {
+    backupModeComboBox_->setCurrentText(tr("SFTP Backup"));
+  } else {
+    backupModeComboBox_->setCurrentText(tr("Local Backup"));
+    destinationDirEdit_->setText(scheduler_->destinationPath());
+  }
+
+  timeListWidget_->clear();
+  QList<ScheduleEntry> entries = scheduler_->scheduleEntries();
+  if (!entries.isEmpty()) {
+    for (const ScheduleEntry &se : entries) {
+      QString data = se.time.toString("HH:mm");
+      QString display = se.time.toString("HH:mm");
+      if (!se.days.isEmpty()) {
+        QStringList names;
+        QStringList nums;
+        int idx = 1;
+        const QStringList dayLabels = {tr("Mon"), tr("Tue"), tr("Wed"),
+                                       tr("Thu"), tr("Fri"), tr("Sat"),
+                                       tr("Sun")};
+        for (Qt::DayOfWeek d : se.days) {
+          names << dayLabels[d - 1];
+          nums << QString::number(int(d));
+        }
+        display += " (" + names.join(',') + ")";
+        data += "|" + nums.join(',');
+      } else {
+        display += tr(" (All)");
+      }
+      QListWidgetItem *item = new QListWidgetItem(display);
+      item->setData(Qt::UserRole, data);
+      timeListWidget_->addItem(item);
+    }
+    backupTimeEdit_->setTime(entries.first().time);
+  } else {
+    backupTimeEdit_->setTime(QTime(23, 0));
+  }
+  onBackupModeChanged(backupModeComboBox_->currentIndex());
+  updateLog("Task details updated in UI from Scheduler state.");
+}
+
+void MainWindow::onBackupModeChanged(int index) {
+  QString currentModeText = backupModeComboBox_->itemText(index);
+  bool localSelected = (currentModeText == tr("Local Backup"));
+  bool sftpSelected = (currentModeText == tr("SFTP Backup"));
+  bool gcsSelected = (currentModeText == tr("Google Cloud Storage"));
+
+  updateLog(QString("Backup mode changing. Selected: %1").arg(currentModeText));
+
+  // End active SFTP listing session if switching away from SFTP mode
+  if (!sftpSelected && sftpTarget_) {
+    updateLog(tr(
+        "Switched away from SFTP mode. Closing active SFTP listing session."));
+    sftpTarget_->endSession();
+    delete sftpTarget_;
+    sftpTarget_ = nullptr;
+    if (sftpConnectToggleButton_) { // Ensure button exists
+      sftpConnectToggleButton_->setText(tr("Connect"));
+    }
+  }
+
+  // End active GCS listing session if switching away from GCS mode
+  if (!gcsSelected && gcsTarget_) {
+    updateLog(
+        tr("Switched away from GCS mode. Closing active GCS listing session."));
+    gcsTarget_->endSession(); // Call directly
+    delete gcsTarget_;
+    gcsTarget_ = nullptr;
+    if (gcsConnectToggleButton_) { // Ensure button exists
+      gcsConnectToggleButton_->setText(tr("Connect"));
+    }
+    // Note: gcsAuthStatusLabel_ is NOT changed here. OAuth state persists.
+  }
+
+  // Always reset file viewer UI elements on any mode change
+  if (fileTableWidget_) {
+    fileTableWidget_->setRowCount(0);
+  }
+  currentRemotePath_ = "/";
+  if (currentPathLabel_) {
+    currentPathLabel_->setText(tr("Path: /"));
+  }
+
+  // Show/hide relevant group boxes
+  if (m_localDestinationGroupBox)
+    m_localDestinationGroupBox->setVisible(localSelected);
+  if (sftpSettingsGroupBox_)
+    sftpSettingsGroupBox_->setVisible(sftpSelected);
+  if (gcsSettingsGroupBox_)
+    gcsSettingsGroupBox_->setVisible(gcsSelected);
+
+  // Show/hide file viewer group box (only for remote modes)
+  bool remoteModeSelected = (sftpSelected || gcsSelected);
+  if (fileViewerDockWidget_) {
+    fileViewerDockWidget_->setVisible(remoteModeSelected);
+  }
+
+  // IMPORTANT: Automatic connection and browsing logic has been removed.
+  // The user now explicitly clicks the "Connect" button for SFTP/GCS listing.
+
+  updateLog(
+      QString(
+          "Backup mode changed to: %1. UI adjusted. File viewer visible: %2.")
+          .arg(currentModeText)
+          .arg(remoteModeSelected ? "Yes" : "No"));
 }
 
 void MainWindow::loadSettings() {
-    QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
-    settings.beginGroup("MainWindow");
+  QSettings settings(QCoreApplication::organizationName(),
+                     QCoreApplication::applicationName());
+  settings.beginGroup("MainWindow");
 
-    const QByteArray geometry = settings.value("geometry", QByteArray()).toByteArray();
-    if (!geometry.isEmpty()) {
-        restoreGeometry(geometry);
-    } else {
-        resize(800, 700);
-    }
-    
-    backupModeComboBox_->setCurrentIndex(settings.value("backupModeIndex", 0).toInt());
-    settings.endGroup();
+  const QByteArray geometry =
+      settings.value("geometry", QByteArray()).toByteArray();
+  if (!geometry.isEmpty()) {
+    restoreGeometry(geometry);
+  } else {
+    resize(800, 700);
+  }
 
-    settings.beginGroup("AutoWatch");
-    watchEnableCheckBox_->setChecked(settings.value("enabled", false).toBool());
-    watchDirEdit_->setText(settings.value("directory", "").toString());
-    settings.endGroup();
+  backupModeComboBox_->setCurrentIndex(
+      settings.value("backupModeIndex", 0).toInt());
+  settings.endGroup();
 
-    if (watchEnableCheckBox_->isChecked()) {
-        onAutoWatchToggled(true);
-    } else {
-        watchStatusLabel_->setText(tr("Surveillance inactive"));
-    }
+  settings.beginGroup("AutoWatch");
+  watchEnableCheckBox_->setChecked(settings.value("enabled", false).toBool());
+  watchDirEdit_->setText(settings.value("directory", "").toString());
+  settings.endGroup();
 
-    settings.beginGroup("SFTP");
-    sftpHostLineEdit_->setText(settings.value("host", "").toString());
-    sftpPortLineEdit_->setText(settings.value("port", "22").toString());
-    sftpUsernameLineEdit_->setText(settings.value("username", "").toString());
-    sftpRemotePathLineEdit_->setText(settings.value("remotePath", "").toString());
-    sftpSavePasswordCheckBox_->setChecked(settings.value("savePassword", false).toBool());
-    settings.endGroup();
+  if (watchEnableCheckBox_->isChecked()) {
+    onAutoWatchToggled(true);
+  } else {
+    watchStatusLabel_->setText(tr("Surveillance inactive"));
+  }
 
-    settings.beginGroup("GCS");
-    gcsBucketNameLineEdit_->setText(settings.value("gcs_bucket_name", "").toString());
-    gcsAccountIdentifierLineEdit_->setText(settings.value("gcs_account_identifier", "").toString());
-    QString lastAuthAccount = settings.value("gcs_last_authenticated_account", "").toString();
-    if (!lastAuthAccount.isEmpty() && lastAuthAccount == gcsAccountIdentifierLineEdit_->text()) {
-        gcsAuthStatusLabel_->setText(tr("Status: Authenticated as %1").arg(lastAuthAccount));
-    } else {
-        gcsAuthStatusLabel_->setText(tr("Status: Not Authenticated"));
-    }
-    settings.endGroup();
-    
-    updateLog("Settings loaded.");
+  settings.beginGroup("SFTP");
+  sftpHostLineEdit_->setText(settings.value("host", "").toString());
+  sftpPortLineEdit_->setText(settings.value("port", "22").toString());
+  sftpUsernameLineEdit_->setText(settings.value("username", "").toString());
+  sftpRemotePathLineEdit_->setText(settings.value("remotePath", "").toString());
+  sftpSavePasswordCheckBox_->setChecked(
+      settings.value("savePassword", false).toBool());
+  settings.endGroup();
+
+  settings.beginGroup("GCS");
+  gcsBucketNameLineEdit_->setText(
+      settings.value("gcs_bucket_name", "").toString());
+  gcsAccountIdentifierLineEdit_->setText(
+      settings.value("gcs_account_identifier", "").toString());
+  QString lastAuthAccount =
+      settings.value("gcs_last_authenticated_account", "").toString();
+  if (!lastAuthAccount.isEmpty() &&
+      lastAuthAccount == gcsAccountIdentifierLineEdit_->text()) {
+    gcsAuthStatusLabel_->setText(
+        tr("Status: Authenticated as %1").arg(lastAuthAccount));
+  } else {
+    gcsAuthStatusLabel_->setText(tr("Status: Not Authenticated"));
+  }
+  settings.endGroup();
+
+  updateLog("Settings loaded.");
 }
 
 void MainWindow::saveSettings() {
-    QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
-    settings.beginGroup("MainWindow");
-    settings.setValue("geometry", saveGeometry());
-    settings.setValue("backupModeIndex", backupModeComboBox_->currentIndex());
-    settings.endGroup();
+  QSettings settings(QCoreApplication::organizationName(),
+                     QCoreApplication::applicationName());
+  settings.beginGroup("MainWindow");
+  settings.setValue("geometry", saveGeometry());
+  settings.setValue("backupModeIndex", backupModeComboBox_->currentIndex());
+  settings.endGroup();
 
-    settings.beginGroup("SFTP");
-    settings.setValue("host", sftpHostLineEdit_->text());
-    settings.setValue("port", sftpPortLineEdit_->text());
-    settings.setValue("username", sftpUsernameLineEdit_->text());
-    settings.setValue("remotePath", sftpRemotePathLineEdit_->text());
-    settings.setValue("savePassword", sftpSavePasswordCheckBox_->isChecked());
-    settings.endGroup();
+  settings.beginGroup("SFTP");
+  settings.setValue("host", sftpHostLineEdit_->text());
+  settings.setValue("port", sftpPortLineEdit_->text());
+  settings.setValue("username", sftpUsernameLineEdit_->text());
+  settings.setValue("remotePath", sftpRemotePathLineEdit_->text());
+  settings.setValue("savePassword", sftpSavePasswordCheckBox_->isChecked());
+  settings.endGroup();
 
-    settings.beginGroup("GCS");
-    settings.setValue("gcs_bucket_name", gcsBucketNameLineEdit_->text());
-    settings.setValue("gcs_account_identifier", gcsAccountIdentifierLineEdit_->text());
-    // gcs_last_authenticated_account is saved only on successful connect
-    settings.endGroup();
+  settings.beginGroup("GCS");
+  settings.setValue("gcs_bucket_name", gcsBucketNameLineEdit_->text());
+  settings.setValue("gcs_account_identifier",
+                    gcsAccountIdentifierLineEdit_->text());
+  // gcs_last_authenticated_account is saved only on successful connect
+  settings.endGroup();
 
-    settings.beginGroup("AutoWatch");
-    settings.setValue("enabled", watchEnableCheckBox_->isChecked());
-    settings.setValue("directory", watchDirEdit_->text());
-    settings.endGroup();
+  settings.beginGroup("AutoWatch");
+  settings.setValue("enabled", watchEnableCheckBox_->isChecked());
+  settings.setValue("directory", watchDirEdit_->text());
+  settings.endGroup();
 
-    if (backupModeComboBox_->currentText() == tr("SFTP Backup")) {
-        QString host = sftpHostLineEdit_->text();
-        QString port = sftpPortLineEdit_->text();
-        QString username = sftpUsernameLineEdit_->text();
-        QString passwordInField = sftpPasswordLineEdit_->text();
+  if (backupModeComboBox_->currentText() == tr("SFTP Backup")) {
+    QString host = sftpHostLineEdit_->text();
+    QString port = sftpPortLineEdit_->text();
+    QString username = sftpUsernameLineEdit_->text();
+    QString passwordInField = sftpPasswordLineEdit_->text();
 
-        if (!host.isEmpty() && !port.isEmpty() && !username.isEmpty() && m_credentialManager) {
-            QString serviceName = QString("sftp_%1_%2").arg(host).arg(port.toInt());
-            if (sftpSavePasswordCheckBox_->isChecked()) {
-                if (!passwordInField.isEmpty()) {
-                    m_credentialManager->storeSecret(serviceName, username, passwordInField);
-                }
-            } else { 
-                m_credentialManager->deleteSecret(serviceName, username);
-            }
+    if (!host.isEmpty() && !port.isEmpty() && !username.isEmpty() &&
+        m_credentialManager) {
+      QString serviceName = QString("sftp_%1_%2").arg(host).arg(port.toInt());
+      if (sftpSavePasswordCheckBox_->isChecked()) {
+        if (!passwordInField.isEmpty()) {
+          m_credentialManager->storeSecret(serviceName, username,
+                                           passwordInField);
         }
+      } else {
+        m_credentialManager->deleteSecret(serviceName, username);
+      }
     }
-    updateLog("Settings saved.");
+  }
+  updateLog("Settings saved.");
 }
 
-void MainWindow::handleScheduledBackup(const QString& sourcePath, const QString& destinationOrIdentifier) {
-    updateLog(QString("Scheduled backup triggered by Scheduler: Source '%1', Dest/ID '%2'")
+void MainWindow::handleScheduledBackup(const QString &sourcePath,
+                                       const QString &destinationOrIdentifier) {
+  updateLog(
+      QString(
+          "Scheduled backup triggered by Scheduler: Source '%1', Dest/ID '%2'")
+          .arg(sourcePath, destinationOrIdentifier));
+
+  IStorageTarget *currentTarget =
+      nullptr; // Local variable for this backup operation
+  // Do not delete this->sftpTarget_ or this->gcsTarget_ (viewer targets)
+  // localTarget_ can be deleted if it's only for one-off local backups from
+  // UI/scheduler For consistency, all scheduled backups will use temporary
+  // targets. If this->localTarget_ was set by runBackupNow, it's already
+  // deleted there or by destructor. If scheduler uses its own parameters, it
+  // should always create a new target.
+
+  if (scheduler_->isGcsMode()) {
+    updateLog("Scheduled task is GCS Mode.");
+    QString bucketName = scheduler_->gcsBucketName();
+    QString accountId = scheduler_->gcsObjectPrefix();
+
+    if (bucketName.isEmpty() || accountId.isEmpty()) {
+      updateLog("Error: Scheduled GCS backup but bucket name or account ID "
+                "(from scheduler's gcsObjectPrefix) is missing in Scheduler.");
+      QMessageBox::critical(this, tr("Scheduled Backup Error"),
+                            tr("GCS configuration for scheduled backup is "
+                               "incomplete (bucket or account ID)."));
+      return;
+    }
+
+    std::map<std::string, std::string> gcsConfig;
+    gcsConfig["gcs_bucket_name"] = bucketName.toStdString();
+    gcsConfig["gcs_account_identifier"] = accountId.toStdString();
+    gcsConfig["gcs_object_prefix"] = "";
+
+    GcsTarget *scheduledGcsTarget =
+        new GcsTarget(gcsConfig, m_credentialManager.get());
+    currentTarget = scheduledGcsTarget;
+    updateLog(QString("Scheduled GCS backup started: From '%1' to GCS Bucket "
+                      "'%2' (Account: '%3')")
+                  .arg(sourcePath, bucketName, accountId));
+
+  } else if (scheduler_->isSftpMode()) {
+    updateLog("Scheduled task is SFTP Mode.");
+    std::map<std::string, std::string> sftpConfig;
+    sftpConfig["host"] = scheduler_->sftpHost().toStdString();
+    sftpConfig["port"] = QString::number(scheduler_->sftpPort()).toStdString();
+    sftpConfig["username"] = scheduler_->sftpUsername().toStdString();
+    sftpConfig["remoteBasePath"] = scheduler_->sftpRemotePath().toStdString();
+    // Password for scheduled SFTP should be retrieved by SftpTarget from
+    // CredentialManager
+    SftpTarget *scheduledSftpTarget = new SftpTarget(sftpConfig);
+    currentTarget = scheduledSftpTarget;
+    updateLog(QString("Scheduled SFTP backup: From '%1' to host '%2'")
+                  .arg(sourcePath, scheduler_->sftpHost()));
+  } else { // Local Mode
+    updateLog("Scheduled task is Local Mode.");
+    if (destinationOrIdentifier.isEmpty()) {
+      updateLog("Error: Scheduled local backup triggered but destination path "
+                "is empty in Scheduler.");
+      QMessageBox::critical(
+          this, tr("Scheduled Backup Error"),
+          tr("Destination path for scheduled local backup is missing."));
+      return;
+    }
+    std::filesystem::path fsDestinationPathFromScheduler(
+        destinationOrIdentifier.toStdString());
+    // For local scheduled backup, ensure it uses the full destination path from
+    // scheduler, not a sub-folder based on source.
+    LocalTarget *scheduledLocalTarget =
+        new LocalTarget(fsDestinationPathFromScheduler.string());
+    currentTarget = scheduledLocalTarget;
+    updateLog(QString("Scheduled Local backup: From '%1' to '%2'")
                   .arg(sourcePath, destinationOrIdentifier));
+  }
 
-    IStorageTarget* currentTarget = nullptr; // Local variable for this backup operation
-    // Do not delete this->sftpTarget_ or this->gcsTarget_ (viewer targets)
-    // localTarget_ can be deleted if it's only for one-off local backups from UI/scheduler
-    // For consistency, all scheduled backups will use temporary targets.
-    // If this->localTarget_ was set by runBackupNow, it's already deleted there or by destructor.
-    // If scheduler uses its own parameters, it should always create a new target.
+  if (!currentTarget) {
+    QMessageBox::critical(
+        this, tr("Scheduled Backup Error"),
+        tr("Failed to initialize backup target for scheduled task."));
+    updateLog("Error: Scheduled backup failed. Target initialization failed.");
+    return;
+  }
 
-    if (scheduler_->isGcsMode()) {
-        updateLog("Scheduled task is GCS Mode.");
-        QString bucketName = scheduler_->gcsBucketName();
-        QString accountId = scheduler_->gcsObjectPrefix();
+  performBackupInternal(sourcePath, currentTarget);
 
-        if (bucketName.isEmpty() || accountId.isEmpty()) {
-            updateLog("Error: Scheduled GCS backup but bucket name or account ID (from scheduler's gcsObjectPrefix) is missing in Scheduler.");
-            QMessageBox::critical(this, tr("Scheduled Backup Error"), tr("GCS configuration for scheduled backup is incomplete (bucket or account ID)."));
-            return;
-        }
-
-        std::map<std::string, std::string> gcsConfig;
-        gcsConfig["gcs_bucket_name"] = bucketName.toStdString();
-        gcsConfig["gcs_account_identifier"] = accountId.toStdString();
-        gcsConfig["gcs_object_prefix"] = "";
-
-        GcsTarget* scheduledGcsTarget = new GcsTarget(gcsConfig, m_credentialManager.get());
-        currentTarget = scheduledGcsTarget;
-        updateLog(QString("Scheduled GCS backup started: From '%1' to GCS Bucket '%2' (Account: '%3')")
-                      .arg(sourcePath, bucketName, accountId));
-
-    } else if (scheduler_->isSftpMode()) {
-        updateLog("Scheduled task is SFTP Mode.");
-        std::map<std::string, std::string> sftpConfig;
-        sftpConfig["host"] = scheduler_->sftpHost().toStdString();
-        sftpConfig["port"] = QString::number(scheduler_->sftpPort()).toStdString();
-        sftpConfig["username"] = scheduler_->sftpUsername().toStdString();
-        sftpConfig["remoteBasePath"] = scheduler_->sftpRemotePath().toStdString();
-        // Password for scheduled SFTP should be retrieved by SftpTarget from CredentialManager
-        SftpTarget* scheduledSftpTarget = new SftpTarget(sftpConfig);
-        currentTarget = scheduledSftpTarget;
-        updateLog(QString("Scheduled SFTP backup: From '%1' to host '%2'")
-                      .arg(sourcePath, scheduler_->sftpHost()));
-    } else { // Local Mode
-        updateLog("Scheduled task is Local Mode.");
-        if (destinationOrIdentifier.isEmpty()) {
-            updateLog("Error: Scheduled local backup triggered but destination path is empty in Scheduler.");
-            QMessageBox::critical(this, tr("Scheduled Backup Error"), tr("Destination path for scheduled local backup is missing."));
-            return;
-        }
-        std::filesystem::path fsDestinationPathFromScheduler(destinationOrIdentifier.toStdString());
-        // For local scheduled backup, ensure it uses the full destination path from scheduler, not a sub-folder based on source.
-        LocalTarget* scheduledLocalTarget = new LocalTarget(fsDestinationPathFromScheduler.string());
-        currentTarget = scheduledLocalTarget;
-        updateLog(QString("Scheduled Local backup: From '%1' to '%2'")
-                      .arg(sourcePath, destinationOrIdentifier));
-    }
-
-    if (!currentTarget) {
-        QMessageBox::critical(this, tr("Scheduled Backup Error"), tr("Failed to initialize backup target for scheduled task."));
-        updateLog("Error: Scheduled backup failed. Target initialization failed.");
-        return;
-    }
-    
-    performBackupInternal(sourcePath, currentTarget);
-
-    // Clean up the temporary target used for this scheduled backup operation
-    delete currentTarget;
-    currentTarget = nullptr;
+  // Clean up the temporary target used for this scheduled backup operation
+  delete currentTarget;
+  currentTarget = nullptr;
 }
 
 // New slots implementation & Remote file viewer methods
-void MainWindow::displayRemoteFiles(const std::vector<FileMetadata>& files) {
-    fileTableWidget_->setRowCount(0); // Clear existing items
+void MainWindow::displayRemoteFiles(const std::vector<FileMetadata> &files) {
+  fileTableWidget_->setRowCount(0); // Clear existing items
 
-    // Add ".." navigation entry if not at root
-    if (currentRemotePath_ != "/") {
-        int row = fileTableWidget_->rowCount();
-        fileTableWidget_->insertRow(row);
+  // Add ".." navigation entry if not at root
+  if (currentRemotePath_ != "/") {
+    int row = fileTableWidget_->rowCount();
+    fileTableWidget_->insertRow(row);
 
-        QIcon dirIcon = QApplication::style()->standardIcon(QStyle::SP_ArrowUp); // Or SP_DirIcon, SP_ArrowUp is more explicit for "up"
-        QTableWidgetItem *nameItem = new QTableWidgetItem(dirIcon, "..");
-        nameItem->setData(Qt::UserRole, true); // isDirectory = true
-        nameItem->setData(Qt::UserRole, true); // isDirectory = true
-        nameItem->setData(Qt::UserRole + 1, ".."); // Actual name for navigation
-        fileTableWidget_->setItem(row, 0, nameItem);
+    QIcon dirIcon = QApplication::style()->standardIcon(
+        QStyle::SP_ArrowUp); // Or SP_DirIcon, SP_ArrowUp is more explicit for
+                             // "up"
+    QTableWidgetItem *nameItem = new QTableWidgetItem(dirIcon, "..");
+    nameItem->setData(Qt::UserRole, true);     // isDirectory = true
+    nameItem->setData(Qt::UserRole, true);     // isDirectory = true
+    nameItem->setData(Qt::UserRole + 1, ".."); // Actual name for navigation
+    fileTableWidget_->setItem(row, 0, nameItem);
 
-        SizeTableWidgetItem *sizeItem = new SizeTableWidgetItem("-");
-        sizeItem->setData(Qt::UserRole, QVariant::fromValue(qlonglong(-2))); // Special value for ".." sorting
-        sizeItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        fileTableWidget_->setItem(row, 1, sizeItem);
+    SizeTableWidgetItem *sizeItem = new SizeTableWidgetItem("-");
+    sizeItem->setData(Qt::UserRole, QVariant::fromValue(qlonglong(
+                                        -2))); // Special value for ".." sorting
+    sizeItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    fileTableWidget_->setItem(row, 1, sizeItem);
 
-        DateTimeTableWidgetItem *dateItem = new DateTimeTableWidgetItem("");
-        dateItem->setData(Qt::UserRole, QVariant::fromValue(qlonglong(0))); // Special value for ".." sorting (very old date)
-        fileTableWidget_->setItem(row, 2, dateItem);
+    DateTimeTableWidgetItem *dateItem = new DateTimeTableWidgetItem("");
+    dateItem->setData(
+        Qt::UserRole,
+        QVariant::fromValue(
+            qlonglong(0))); // Special value for ".." sorting (very old date)
+    fileTableWidget_->setItem(row, 2, dateItem);
 
-        fileTableWidget_->setItem(row, 3, new QTableWidgetItem(tr("Parent Directory")));
+    fileTableWidget_->setItem(row, 3,
+                              new QTableWidgetItem(tr("Parent Directory")));
+  }
+
+  for (const auto &file : files) {
+    int row = fileTableWidget_->rowCount();
+    fileTableWidget_->insertRow(row);
+
+    QIcon icon = QApplication::style()->standardIcon(
+        file.isDirectory ? QStyle::SP_DirIcon : QStyle::SP_FileIcon);
+    QTableWidgetItem *nameItem =
+        new QTableWidgetItem(icon, QString::fromStdString(file.name));
+    nameItem->setData(Qt::UserRole, file.isDirectory);
+    nameItem->setData(Qt::UserRole + 1,
+                      QString::fromStdString(file.name)); // Store actual name
+    fileTableWidget_->setItem(row, 0, nameItem);
+
+    SizeTableWidgetItem *sizeItem;
+    if (file.isDirectory) {
+      sizeItem = new SizeTableWidgetItem("-");
+      // Store a value that helps sort directories together, e.g., -1, if ".."
+      // uses -2
+      sizeItem->setData(Qt::UserRole, QVariant::fromValue(qlonglong(-1)));
+    } else {
+      // Basic size formatting (could be enhanced to KB/MB/GB)
+      QString formattedSize =
+          QString::number(file.size) + " B"; // Placeholder, can be improved
+      sizeItem = new SizeTableWidgetItem(formattedSize,
+                                         static_cast<qlonglong>(file.size));
     }
+    sizeItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    fileTableWidget_->setItem(row, 1, sizeItem);
 
-    for (const auto& file : files) {
-        int row = fileTableWidget_->rowCount();
-        fileTableWidget_->insertRow(row);
+    qint64 secs =
+        static_cast<qint64>(std::chrono::duration_cast<std::chrono::seconds>(
+                                file.modificationTime.time_since_epoch())
+                                .count());
 
-        QIcon icon = QApplication::style()->standardIcon(file.isDirectory ? QStyle::SP_DirIcon : QStyle::SP_FileIcon);
-        QTableWidgetItem *nameItem = new QTableWidgetItem(icon, QString::fromStdString(file.name));
-        nameItem->setData(Qt::UserRole, file.isDirectory);
-        nameItem->setData(Qt::UserRole + 1, QString::fromStdString(file.name)); // Store actual name
-        fileTableWidget_->setItem(row, 0, nameItem);
-
-        SizeTableWidgetItem *sizeItem;
-        if (file.isDirectory) {
-            sizeItem = new SizeTableWidgetItem("-");
-            // Store a value that helps sort directories together, e.g., -1, if ".." uses -2
-            sizeItem->setData(Qt::UserRole, QVariant::fromValue(qlonglong(-1)));
-        } else {
-            // Basic size formatting (could be enhanced to KB/MB/GB)
-            QString formattedSize = QString::number(file.size) + " B"; // Placeholder, can be improved
-            sizeItem = new SizeTableWidgetItem(formattedSize, static_cast<qlonglong>(file.size));
-        }
-        sizeItem->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
-        fileTableWidget_->setItem(row, 1, sizeItem);
-
-        qint64 secs = static_cast<qint64>(
-                          std::chrono::duration_cast<std::chrono::seconds>(
-                              file.modificationTime.time_since_epoch()).count());
-
-        QDateTime modDateTime = QDateTime::fromSecsSinceEpoch(secs);
+    QDateTime modDateTime = QDateTime::fromSecsSinceEpoch(secs);
     QString formattedDate = modDateTime.toString(Qt::TextDate);
 
+    DateTimeTableWidgetItem *dateItem = new DateTimeTableWidgetItem(
+        formattedDate, secs); // New line using qint64 secs
+    fileTableWidget_->setItem(row, 2, dateItem);
 
-        DateTimeTableWidgetItem *dateItem =
-                new DateTimeTableWidgetItem(formattedDate, secs); // New line using qint64 secs
-        fileTableWidget_->setItem(row, 2, dateItem);
-
-        fileTableWidget_->setItem(row, 3, new QTableWidgetItem(file.isDirectory ? tr("Folder") : tr("File")));
-    }
+    fileTableWidget_->setItem(
+        row, 3,
+        new QTableWidgetItem(file.isDirectory ? tr("Folder") : tr("File")));
+  }
 }
 
-void MainWindow::browseRemotePath(const QString& path) {
-    currentRemotePath_ = path;
-    // Update the path label immediately. If listing fails or not connected, path still shows intent.
-    if (currentPathLabel_) {
-        currentPathLabel_->setText(tr("Path: ") + currentRemotePath_);
+void MainWindow::browseRemotePath(const QString &path) {
+  currentRemotePath_ = path;
+  // Update the path label immediately. If listing fails or not connected, path
+  // still shows intent.
+  if (currentPathLabel_) {
+    currentPathLabel_->setText(tr("Path: ") + currentRemotePath_);
+  }
+  updateLog(tr("Attempting to browse remote path: %1").arg(path));
+
+  std::vector<FileMetadata> files;
+  QString currentModeText = backupModeComboBox_->currentText();
+
+  if (currentModeText == tr("Google Cloud Storage")) {
+    if (!gcsTarget_) { // Check if GCS target for listing exists (i.e.,
+                       // "Connect" was clicked)
+      updateLog(tr("GCS browse attempted but not connected for listing. Please "
+                   "use the 'Connect' button first."));
+      // Display empty list, user sees "Connect" button.
+      displayRemoteFiles({}); // Ensure view is empty
+      // Optionally, could show a QMessageBox::information here, but an empty
+      // table + visible Connect button is also clear.
+      return;
     }
-    updateLog(tr("Attempting to browse remote path: %1").arg(path));
-
-    std::vector<FileMetadata> files;
-    QString currentModeText = backupModeComboBox_->currentText();
-
-    if (currentModeText == tr("Google Cloud Storage")) {
-        if (!gcsTarget_) { // Check if GCS target for listing exists (i.e., "Connect" was clicked)
-            updateLog(tr("GCS browse attempted but not connected for listing. Please use the 'Connect' button first."));
-            // Display empty list, user sees "Connect" button.
-            displayRemoteFiles({}); // Ensure view is empty
-            // Optionally, could show a QMessageBox::information here, but an empty table + visible Connect button is also clear.
-            return;
-        }
-        // If gcsTarget_ exists, assume it's connected (beginSession was successful in onGcsConnectToggleClicked)
-        files = gcsTarget_->listFiles(path.toStdString());
-        if (!gcsTarget_->getLastError().empty()) {
-            QMessageBox::critical(this, tr("GCS Error"), tr("Failed to list files: %1").arg(QString::fromStdString(gcsTarget_->getLastError())));
-            updateLog(tr("GCS listFiles failed for path '%1': %2").arg(path, QString::fromStdString(gcsTarget_->getLastError())));
-            // files will be empty or partially filled, displayRemoteFiles will show what was returned.
-        }
-    } else if (currentModeText == tr("SFTP Backup")) {
-        if (!sftpTarget_ || !sftpTarget_->isSessionOpen()) {
-            updateLog(tr("SFTP viewer not connected or session invalid. Please use the 'Connect' button."));
-            if (fileTableWidget_) { // Ensure table exists before modifying
-                displayRemoteFiles({}); // Clear view by displaying an empty list
-            }
-            // Optional: Consider if sftpConnectToggleButton_ text should be reset to "Connect" here.
-            // If sftpTarget_ exists but session is not open, it implies an inconsistent state.
-            // For now, the primary goal is to prevent listFiles on an invalid session and clear the view.
-            // if (sftpConnectToggleButton_ && sftpTarget_ && !sftpTarget_->isSessionOpen()) {
-            //     sftpConnectToggleButton_->setText(tr("Connect"));
-            // }
-            return;
-        }
-        // If sftpTarget_ exists AND session is open...
-        files = sftpTarget_->listFiles(path.toStdString());
-        // Temporary diagnostic log for SFTP
-        updateLog(QString("SFTP listFiles returned %1 items").arg(files.size()));
-
-        if (!sftpTarget_->getLastError().empty()) { // Assuming SftpTarget gets a getLastError()
-            QMessageBox::critical(this, tr("SFTP Error"), tr("Failed to list files: %1").arg(QString::fromStdString(sftpTarget_->getLastError())));
-            updateLog(tr("SFTP listFiles failed for path '%1': %2").arg(path, QString::fromStdString(sftpTarget_->getLastError())));
-        }
-    } else {
-        // This case should ideally not be reached if fileViewerGroupBox is only visible in remote modes
-        updateLog(tr("BrowseRemotePath called in non-remote mode: %1. Clearing view.").arg(currentModeText));
-        displayRemoteFiles({}); // Display empty list
-        return;
+    // If gcsTarget_ exists, assume it's connected (beginSession was successful
+    // in onGcsConnectToggleClicked)
+    files = gcsTarget_->listFiles(path.toStdString());
+    if (!gcsTarget_->getLastError().empty()) {
+      QMessageBox::critical(
+          this, tr("GCS Error"),
+          tr("Failed to list files: %1")
+              .arg(QString::fromStdString(gcsTarget_->getLastError())));
+      updateLog(
+          tr("GCS listFiles failed for path '%1': %2")
+              .arg(path, QString::fromStdString(gcsTarget_->getLastError())));
+      // files will be empty or partially filled, displayRemoteFiles will show
+      // what was returned.
     }
-    displayRemoteFiles(files);
-    updateLog(tr("Displayed %1 files/folders for path: %2").arg(files.size()).arg(path));
+  } else if (currentModeText == tr("SFTP Backup")) {
+    if (!sftpTarget_ || !sftpTarget_->isSessionOpen()) {
+      updateLog(tr("SFTP viewer not connected or session invalid. Please use "
+                   "the 'Connect' button."));
+      if (fileTableWidget_) {   // Ensure table exists before modifying
+        displayRemoteFiles({}); // Clear view by displaying an empty list
+      }
+      // Optional: Consider if sftpConnectToggleButton_ text should be reset to
+      // "Connect" here. If sftpTarget_ exists but session is not open, it
+      // implies an inconsistent state. For now, the primary goal is to prevent
+      // listFiles on an invalid session and clear the view. if
+      // (sftpConnectToggleButton_ && sftpTarget_ &&
+      // !sftpTarget_->isSessionOpen()) {
+      //     sftpConnectToggleButton_->setText(tr("Connect"));
+      // }
+      return;
+    }
+    // If sftpTarget_ exists AND session is open...
+    files = sftpTarget_->listFiles(path.toStdString());
+    // Temporary diagnostic log for SFTP
+    updateLog(QString("SFTP listFiles returned %1 items").arg(files.size()));
+
+    if (!sftpTarget_->getLastError()
+             .empty()) { // Assuming SftpTarget gets a getLastError()
+      QMessageBox::critical(
+          this, tr("SFTP Error"),
+          tr("Failed to list files: %1")
+              .arg(QString::fromStdString(sftpTarget_->getLastError())));
+      updateLog(
+          tr("SFTP listFiles failed for path '%1': %2")
+              .arg(path, QString::fromStdString(sftpTarget_->getLastError())));
+    }
+  } else {
+    // This case should ideally not be reached if fileViewerGroupBox is only
+    // visible in remote modes
+    updateLog(
+        tr("BrowseRemotePath called in non-remote mode: %1. Clearing view.")
+            .arg(currentModeText));
+    displayRemoteFiles({}); // Display empty list
+    return;
+  }
+  displayRemoteFiles(files);
+  updateLog(tr("Displayed %1 files/folders for path: %2")
+                .arg(files.size())
+                .arg(path));
 }
 
 void MainWindow::onFileViewerRefreshClicked() {
-    updateLog("File viewer refresh clicked. Current path: " + currentRemotePath_);
-    browseRemotePath(currentRemotePath_);
+  updateLog("File viewer refresh clicked. Current path: " + currentRemotePath_);
+  browseRemotePath(currentRemotePath_);
 }
 
 void MainWindow::onFileViewerDownloadClicked() {
-    // Session Checks
-    QString currentModeText = backupModeComboBox_->currentText(); // Get current mode
+  // Session Checks
+  QString currentModeText =
+      backupModeComboBox_->currentText(); // Get current mode
 
-    if (currentModeText == tr("SFTP Backup")) {
-        if (!sftpTarget_ || !sftpTarget_->isSessionOpen()) {
-            updateLog(tr("SFTP Download: Not connected or session invalid. Please connect viewer session."));
-            QMessageBox::warning(this, tr("SFTP Download Error"), tr("SFTP session is not active. Please use the 'Connect' button for the SFTP viewer first."));
-            return;
-        }
-    } else if (currentModeText == tr("Google Cloud Storage")) {
-        if (!gcsTarget_) { // For GCS, gcsTarget_ existing implies an attempt to connect for listing was made.
-                           // Actual token validity is handled by GCS operations.
-            updateLog(tr("GCS Download: Not connected for listing. Please use the GCS 'Connect' button for listing first."));
-            QMessageBox::warning(this, tr("GCS Download Error"), tr("GCS session for listing is not active. Please use the 'Connect' (for listing) button first."));
-            return;
-        }
+  if (currentModeText == tr("SFTP Backup")) {
+    if (!sftpTarget_ || !sftpTarget_->isSessionOpen()) {
+      updateLog(tr("SFTP Download: Not connected or session invalid. Please "
+                   "connect viewer session."));
+      QMessageBox::warning(this, tr("SFTP Download Error"),
+                           tr("SFTP session is not active. Please use the "
+                              "'Connect' button for the SFTP viewer first."));
+      return;
+    }
+  } else if (currentModeText == tr("Google Cloud Storage")) {
+    if (!gcsTarget_) { // For GCS, gcsTarget_ existing implies an attempt to
+                       // connect for listing was made. Actual token validity is
+                       // handled by GCS operations.
+      updateLog(tr("GCS Download: Not connected for listing. Please use the "
+                   "GCS 'Connect' button for listing first."));
+      QMessageBox::warning(this, tr("GCS Download Error"),
+                           tr("GCS session for listing is not active. Please "
+                              "use the 'Connect' (for listing) button first."));
+      return;
+    }
+  } else {
+    // Should not happen if download button is only enabled for remote modes,
+    // but good to have.
+    updateLog(tr("Download Error: Download is not available for the current "
+                 "backup mode."));
+    QMessageBox::warning(
+        this, tr("Download Error"),
+        tr("Download is not available for the current backup mode."));
+    return;
+  }
+
+  QList<QTableWidgetItem *> selectedItems = fileTableWidget_->selectedItems();
+  if (selectedItems.isEmpty() || selectedItems.first()->row() < 0) {
+    QMessageBox::information(this, tr("Download"),
+                             tr("No file selected or invalid selection."));
+    return;
+  }
+  // Ensure the first item (column 0) of the selected row is used for name data
+  QTableWidgetItem *nameItem =
+      fileTableWidget_->item(selectedItems.first()->row(), 0);
+  if (!nameItem) {
+    QMessageBox::warning(this, tr("Download Error"),
+                         tr("Could not retrieve item data."));
+    return;
+  }
+
+  bool isDir = nameItem->data(Qt::UserRole).toBool();
+  QString actualFileName =
+      nameItem->data(Qt::UserRole + 1).toString(); // Actual name from metadata
+
+  if (isDir) {
+    QMessageBox::information(
+        this, tr("Download"),
+        tr("Folder download is not implemented for this item type."));
+    return;
+  }
+  if (actualFileName ==
+      "..") { // Should not happen if selection is managed, but good check
+    QMessageBox::information(this, tr("Download"), tr("Cannot download '..'."));
+    return;
+  }
+
+  QString remoteFilePath = currentRemotePath_;
+  if (remoteFilePath.endsWith("/")) {
+    remoteFilePath += actualFileName;
+  } else {
+    remoteFilePath += "/" + actualFileName;
+  }
+  remoteFilePath = QDir::cleanPath(remoteFilePath);
+
+  QString localPath =
+      QFileDialog::getSaveFileName(this, tr("Save File"), actualFileName);
+  if (localPath.isEmpty()) {
+    return; // User cancelled
+  }
+
+  updateLog(tr("Attempting to download remote file '%1' to '%2'")
+                .arg(remoteFilePath, localPath));
+
+  bool success = false;
+  QString errorMsg;
+  // currentModeText is already defined and checked at the top of the function.
+
+  if (currentModeText == tr("Google Cloud Storage")) {
+    // Redundant check removed: if (!gcsTarget_)
+    if (gcsTarget_->downloadFile(remoteFilePath.toStdString(),
+                                 localPath.toStdString())) {
+      success = true;
     } else {
-        // Should not happen if download button is only enabled for remote modes, but good to have.
-        updateLog(tr("Download Error: Download is not available for the current backup mode."));
-        QMessageBox::warning(this, tr("Download Error"), tr("Download is not available for the current backup mode."));
-        return;
+      errorMsg = QString::fromStdString(gcsTarget_->getLastError());
     }
-
-    QList<QTableWidgetItem*> selectedItems = fileTableWidget_->selectedItems();
-    if (selectedItems.isEmpty() || selectedItems.first()->row() < 0) {
-        QMessageBox::information(this, tr("Download"), tr("No file selected or invalid selection."));
-        return;
-    }
-    // Ensure the first item (column 0) of the selected row is used for name data
-    QTableWidgetItem* nameItem = fileTableWidget_->item(selectedItems.first()->row(), 0);
-    if (!nameItem) {
-         QMessageBox::warning(this, tr("Download Error"), tr("Could not retrieve item data."));
-        return;
-    }
-
-    bool isDir = nameItem->data(Qt::UserRole).toBool();
-    QString actualFileName = nameItem->data(Qt::UserRole + 1).toString(); // Actual name from metadata
-
-    if (isDir) {
-        QMessageBox::information(this, tr("Download"), tr("Folder download is not implemented for this item type."));
-        return;
-    }
-    if (actualFileName == "..") { // Should not happen if selection is managed, but good check
-        QMessageBox::information(this, tr("Download"), tr("Cannot download '..'."));
-        return;
-    }
-
-    QString remoteFilePath = currentRemotePath_;
-    if (remoteFilePath.endsWith("/")) {
-        remoteFilePath += actualFileName;
+  } else if (currentModeText == tr("SFTP Backup")) {
+    // Redundant check removed: if (!sftpTarget_)
+    // SFTP downloadFile expects path relative to its base.
+    // Our currentRemotePath_ is already relative to SFTP base if m_objectPrefix
+    // is used correctly by SftpTarget. Or, if currentRemotePath_ is absolute
+    // from SFTP root, then SftpTarget's remotePath needs that. For now, assume
+    // remoteFilePath as constructed is what SftpTarget expects.
+    if (sftpTarget_->downloadFile(remoteFilePath.toStdString(),
+                                  localPath.toStdString())) {
+      success = true;
     } else {
-        remoteFilePath += "/" + actualFileName;
+      errorMsg = QString::fromStdString(sftpTarget_->getLastError());
+      if (errorMsg.isEmpty()) { // Fallback if getLastError was empty but
+                                // download still failed
+        errorMsg = tr("SFTP download failed. Please check logs or ensure the "
+                      "file path is correct and accessible.");
+      }
     }
-    remoteFilePath = QDir::cleanPath(remoteFilePath);
+  }
+  // The 'else' case for unsupported modes is handled by the checks at the top
+  // of the function.
 
-
-    QString localPath = QFileDialog::getSaveFileName(this, tr("Save File"), actualFileName);
-    if (localPath.isEmpty()) {
-        return; // User cancelled
-    }
-
-    updateLog(tr("Attempting to download remote file '%1' to '%2'").arg(remoteFilePath, localPath));
-
-    bool success = false;
-    QString errorMsg;
-    // currentModeText is already defined and checked at the top of the function.
-
-    if (currentModeText == tr("Google Cloud Storage")) {
-        // Redundant check removed: if (!gcsTarget_)
-        if (gcsTarget_->downloadFile(remoteFilePath.toStdString(), localPath.toStdString())) {
-            success = true;
-        } else {
-            errorMsg = QString::fromStdString(gcsTarget_->getLastError());
-        }
-    } else if (currentModeText == tr("SFTP Backup")) {
-        // Redundant check removed: if (!sftpTarget_)
-        // SFTP downloadFile expects path relative to its base.
-        // Our currentRemotePath_ is already relative to SFTP base if m_objectPrefix is used correctly by SftpTarget.
-        // Or, if currentRemotePath_ is absolute from SFTP root, then SftpTarget's remotePath needs that.
-        // For now, assume remoteFilePath as constructed is what SftpTarget expects.
-        if (sftpTarget_->downloadFile(remoteFilePath.toStdString(), localPath.toStdString())) {
-            success = true;
-        } else {
-            errorMsg = QString::fromStdString(sftpTarget_->getLastError());
-            if (errorMsg.isEmpty()) { // Fallback if getLastError was empty but download still failed
-                errorMsg = tr("SFTP download failed. Please check logs or ensure the file path is correct and accessible.");
-            }
-        }
-    }
-    // The 'else' case for unsupported modes is handled by the checks at the top of the function.
-
-    if (success) {
-        QMessageBox::information(this, tr("Download Complete"), tr("File '%1' downloaded successfully to '%2'.").arg(actualFileName, localPath));
-        updateLog(tr("Successfully downloaded '%1' to '%2'.").arg(remoteFilePath, localPath));
-    } else {
-        QMessageBox::critical(this, tr("Download Failed"), tr("Failed to download '%1'. Error: %2").arg(actualFileName, errorMsg));
-        updateLog(tr("Failed to download '%1'. Error: %2").arg(remoteFilePath, errorMsg));
-    }
+  if (success) {
+    QMessageBox::information(this, tr("Download Complete"),
+                             tr("File '%1' downloaded successfully to '%2'.")
+                                 .arg(actualFileName, localPath));
+    updateLog(tr("Successfully downloaded '%1' to '%2'.")
+                  .arg(remoteFilePath, localPath));
+  } else {
+    QMessageBox::critical(
+        this, tr("Download Failed"),
+        tr("Failed to download '%1'. Error: %2").arg(actualFileName, errorMsg));
+    updateLog(
+        tr("Failed to download '%1'. Error: %2").arg(remoteFilePath, errorMsg));
+  }
 }
 
 void MainWindow::onFileViewerDeleteClicked() {
-    QList<QTableWidgetItem*> selectedItems = fileTableWidget_->selectedItems();
-    if (selectedItems.isEmpty() || selectedItems.first()->row() < 0) {
-        QMessageBox::information(this, tr("Delete"), tr("No file selected or invalid selection."));
-        return;
-    }
-    int selectedRow = selectedItems.first()->row();
+  QList<QTableWidgetItem *> selectedItems = fileTableWidget_->selectedItems();
+  if (selectedItems.isEmpty() || selectedItems.first()->row() < 0) {
+    QMessageBox::information(this, tr("Delete"),
+                             tr("No file selected or invalid selection."));
+    return;
+  }
+  int selectedRow = selectedItems.first()->row();
 
-    QTableWidgetItem* nameItemWidget = fileTableWidget_->item(selectedRow, 0); // Name is in column 0
-    if (!nameItemWidget) {
-        QMessageBox::warning(this, tr("Delete Error"), tr("Could not retrieve item data for selected row %1.").arg(selectedRow));
-        return;
-    }
+  QTableWidgetItem *nameItemWidget =
+      fileTableWidget_->item(selectedRow, 0); // Name is in column 0
+  if (!nameItemWidget) {
+    QMessageBox::warning(this, tr("Delete Error"),
+                         tr("Could not retrieve item data for selected row %1.")
+                             .arg(selectedRow));
+    return;
+  }
 
-    QString actualFileName = nameItemWidget->data(Qt::UserRole + 1).toString();
-    bool isDirectory = nameItemWidget->data(Qt::UserRole).toBool();
+  QString actualFileName = nameItemWidget->data(Qt::UserRole + 1).toString();
+  bool isDirectory = nameItemWidget->data(Qt::UserRole).toBool();
 
-    if (actualFileName.isEmpty()) {
-        QMessageBox::warning(this, tr("Delete Error"), tr("Invalid or empty file name selected."));
-        updateLog(tr("SFTP Delete: Attempted to delete an item with an empty name."));
-        return;
-    }
-    if (actualFileName == "..") {
-        QMessageBox::information(this, tr("Delete Error"), tr("Cannot delete the parent directory navigation entry."));
-        return;
-    }
+  if (actualFileName.isEmpty()) {
+    QMessageBox::warning(this, tr("Delete Error"),
+                         tr("Invalid or empty file name selected."));
+    updateLog(
+        tr("SFTP Delete: Attempted to delete an item with an empty name."));
+    return;
+  }
+  if (actualFileName == "..") {
+    QMessageBox::information(
+        this, tr("Delete Error"),
+        tr("Cannot delete the parent directory navigation entry."));
+    return;
+  }
 
-    QString fullRemotePath = currentRemotePath_;
-    if (fullRemotePath.endsWith('/')) {
-        fullRemotePath += actualFileName;
+  QString fullRemotePath = currentRemotePath_;
+  if (fullRemotePath.endsWith('/')) {
+    fullRemotePath += actualFileName;
+  } else {
+    fullRemotePath += "/" + actualFileName;
+  }
+  fullRemotePath = QDir::cleanPath(fullRemotePath);
+
+  QMessageBox::StandardButton reply;
+  QString itemTypeForMessage = isDirectory ? tr(" (Directory)") : "";
+  reply = QMessageBox::warning(this, tr("Confirm Delete"),
+                               tr("Are you sure you want to delete '%1'%2?")
+                                   .arg(actualFileName, itemTypeForMessage),
+                               QMessageBox::Yes | QMessageBox::No);
+
+  if (reply == QMessageBox::No) {
+    return;
+  }
+
+  updateLog(tr("User confirmed deletion of: %1 (isDirectory: %2)")
+                .arg(fullRemotePath, isDirectory ? "true" : "false"));
+
+  bool success = false;
+  QString errorMsg;
+  QString currentModeText = backupModeComboBox_->currentText();
+
+  if (currentModeText == tr("Google Cloud Storage")) {
+    if (!gcsTarget_) {
+      QMessageBox::critical(this, tr("GCS Error"),
+                            tr("GCS target not initialized. Cannot delete."));
+      return;
+    }
+    if (isDirectory) {
+      // GCS: Deleting "folders" (prefixes) is complex.
+      // It requires listing all objects under the prefix and deleting them
+      // individually. This is a non-trivial operation and typically not done
+      // with a single "delete" call.
+      errorMsg =
+          tr("Deleting folders/prefixes in GCS requires deleting all contained "
+             "objects and is not implemented as a single operation.");
+      QMessageBox::information(this, tr("GCS Delete Info"), errorMsg);
+      updateLog("GCS delete directory attempted: " + errorMsg);
+      return; // Don't proceed with gcsTarget->deleteFile for directories
+    }
+    // Proceed with file deletion for GCS
+    if (gcsTarget_->deleteFile(fullRemotePath.toStdString())) {
+      success = true;
     } else {
-        fullRemotePath += "/" + actualFileName;
+      errorMsg = QString::fromStdString(gcsTarget_->getLastError());
     }
-    fullRemotePath = QDir::cleanPath(fullRemotePath);
-
-    QMessageBox::StandardButton reply;
-    QString itemTypeForMessage = isDirectory ? tr(" (Directory)") : "";
-    reply = QMessageBox::warning(this, tr("Confirm Delete"),
-                                 tr("Are you sure you want to delete '%1'%2?").arg(actualFileName, itemTypeForMessage),
-                                 QMessageBox::Yes | QMessageBox::No);
-
-    if (reply == QMessageBox::No) {
-        return;
+  } else if (currentModeText == tr("SFTP Backup")) {
+    // Add this new, more comprehensive check:
+    if (!sftpTarget_ || !sftpTarget_->isSessionOpen()) {
+      QMessageBox::warning(
+          this, tr("SFTP Delete Error"),
+          tr("SFTP session is not active or invalid. Please connect first."));
+      updateLog(tr("SFTP Delete: Attempted to delete when session was not "
+                   "active for file '%1'.")
+                    .arg(actualFileName));
+      return;
     }
-
-    updateLog(tr("User confirmed deletion of: %1 (isDirectory: %2)").arg(fullRemotePath, isDirectory ? "true" : "false"));
-
-    bool success = false;
-    QString errorMsg;
-    QString currentModeText = backupModeComboBox_->currentText();
-
-    if (currentModeText == tr("Google Cloud Storage")) {
-        if (!gcsTarget_) {
-            QMessageBox::critical(this, tr("GCS Error"), tr("GCS target not initialized. Cannot delete."));
-            return;
-        }
-        if (isDirectory) {
-            // GCS: Deleting "folders" (prefixes) is complex.
-            // It requires listing all objects under the prefix and deleting them individually.
-            // This is a non-trivial operation and typically not done with a single "delete" call.
-            errorMsg = tr("Deleting folders/prefixes in GCS requires deleting all contained objects and is not implemented as a single operation.");
-            QMessageBox::information(this, tr("GCS Delete Info"), errorMsg);
-            updateLog("GCS delete directory attempted: " + errorMsg);
-            return; // Don't proceed with gcsTarget->deleteFile for directories
-        }
-        // Proceed with file deletion for GCS
-        if (gcsTarget_->deleteFile(fullRemotePath.toStdString())) {
-            success = true;
-        } else {
-            errorMsg = QString::fromStdString(gcsTarget_->getLastError());
-        }
-    } else if (currentModeText == tr("SFTP Backup")) {
-        // Add this new, more comprehensive check:
-        if (!sftpTarget_ || !sftpTarget_->isSessionOpen()) {
-            QMessageBox::warning(this, tr("SFTP Delete Error"), tr("SFTP session is not active or invalid. Please connect first."));
-            updateLog(tr("SFTP Delete: Attempted to delete when session was not active for file '%1'.").arg(actualFileName));
-            return;
-        }
-        if (isDirectory) {
-            // SFTP: Standard SFTP 'rm' typically doesn't remove directories unless empty.
-            // 'rmdir' is for empty directories. Recursive delete usually needs server-side support or client-side recursion.
-            // The current SftpTarget::deleteFile uses "rm", so it will likely fail for non-empty dirs.
-            // We can inform the user or attempt it and let the server decide.
-            updateLog(tr("Attempting to delete SFTP directory '%1' using 'rm'. This may only work for empty directories or if server allows 'rm' on dirs.").arg(fullRemotePath));
-            // Proceed to call deleteFile, server error will be reported if it fails.
-        }
-        if (sftpTarget_->deleteFile(fullRemotePath.toStdString())) {
-            success = true;
-        } else {
-            errorMsg = tr("SFTP delete failed. Check logs. The server might not allow 'rm' on directories or the directory was not empty.");
-            // TODO: SftpTarget should ideally provide specific error via getLastError()
-        }
+    if (isDirectory) {
+      // SFTP: Standard SFTP 'rm' typically doesn't remove directories unless
+      // empty. 'rmdir' is for empty directories. Recursive delete usually needs
+      // server-side support or client-side recursion. The current
+      // SftpTarget::deleteFile uses "rm", so it will likely fail for non-empty
+      // dirs. We can inform the user or attempt it and let the server decide.
+      updateLog(tr("Attempting to delete SFTP directory '%1' using 'rm'. This "
+                   "may only work for empty directories or if server allows "
+                   "'rm' on dirs.")
+                    .arg(fullRemotePath));
+      // Proceed to call deleteFile, server error will be reported if it fails.
+    }
+    if (sftpTarget_->deleteFile(fullRemotePath.toStdString())) {
+      success = true;
     } else {
-        QMessageBox::warning(this, tr("Delete Error"), tr("Delete is not supported for the current backup mode."));
-        return;
+      errorMsg =
+          tr("SFTP delete failed. Check logs. The server might not allow 'rm' "
+             "on directories or the directory was not empty.");
+      // TODO: SftpTarget should ideally provide specific error via
+      // getLastError()
     }
+  } else {
+    QMessageBox::warning(
+        this, tr("Delete Error"),
+        tr("Delete is not supported for the current backup mode."));
+    return;
+  }
 
-    if (success) {
-        QMessageBox::information(this, tr("Delete Successful"), tr("'%1' deleted successfully.").arg(actualFileName));
-        updateLog(tr("Successfully deleted '%1'.").arg(fullRemotePath));
-        if (selectedRow >= 0 && selectedRow < fileTableWidget_->rowCount()) {
-            fileTableWidget_->removeRow(selectedRow);
-            updateLog(tr("Removed item from view at row %1.").arg(selectedRow));
-        } else {
-            updateLog(tr("Could not remove item from view, row %1 invalid or table changed. Forcing refresh.").arg(selectedRow));
-            onFileViewerRefreshClicked(); // Fallback to refresh
-        }
+  if (success) {
+    QMessageBox::information(
+        this, tr("Delete Successful"),
+        tr("'%1' deleted successfully.").arg(actualFileName));
+    updateLog(tr("Successfully deleted '%1'.").arg(fullRemotePath));
+    if (selectedRow >= 0 && selectedRow < fileTableWidget_->rowCount()) {
+      fileTableWidget_->removeRow(selectedRow);
+      updateLog(tr("Removed item from view at row %1.").arg(selectedRow));
     } else {
-        QMessageBox::critical(this, tr("Delete Failed"), tr("Failed to delete '%1'. Error: %2").arg(actualFileName, errorMsg));
-        updateLog(tr("Failed to delete '%1'. Error: %2").arg(fullRemotePath, errorMsg));
+      updateLog(tr("Could not remove item from view, row %1 invalid or table "
+                   "changed. Forcing refresh.")
+                    .arg(selectedRow));
+      onFileViewerRefreshClicked(); // Fallback to refresh
     }
+  } else {
+    QMessageBox::critical(
+        this, tr("Delete Failed"),
+        tr("Failed to delete '%1'. Error: %2").arg(actualFileName, errorMsg));
+    updateLog(
+        tr("Failed to delete '%1'. Error: %2").arg(fullRemotePath, errorMsg));
+  }
 }
 
 void MainWindow::onFileTableItemDoubleClicked(QTableWidgetItem *item) {
-    if (!item) return;
+  if (!item)
+    return;
 
-    // Ensure we are using the data from column 0 (Name column) for path construction
-    QTableWidgetItem *nameColItem = fileTableWidget_->item(item->row(), 0);
-    if (!nameColItem) return; // Should not happen if item itself is valid
+  // Ensure we are using the data from column 0 (Name column) for path
+  // construction
+  QTableWidgetItem *nameColItem = fileTableWidget_->item(item->row(), 0);
+  if (!nameColItem)
+    return; // Should not happen if item itself is valid
 
-    bool isDir = nameColItem->data(Qt::UserRole).toBool();
-    QString itemName = nameColItem->data(Qt::UserRole + 1).toString(); // Get actual name from metadata
+  bool isDir = nameColItem->data(Qt::UserRole).toBool();
+  QString itemName = nameColItem->data(Qt::UserRole + 1)
+                         .toString(); // Get actual name from metadata
 
-    if (isDir) {
-        if (itemName == "..") {
-            QDir dir(currentRemotePath_);
-            if (dir.cdUp()) {
-                QString parentPath = dir.path();
-                // Ensure root path is just "/"
-                if (parentPath.isEmpty() || parentPath == "." || parentPath == "//") {
-                    parentPath = "/";
-                }
-                // QDir might return "/." for parent of "/foo", clean it.
-                if (parentPath.endsWith("/.")) {
-                    parentPath = parentPath.left(parentPath.length() - 2);
-                    if (parentPath.isEmpty()) parentPath = "/";
-                }
-                 updateLog("Navigating up to: " + parentPath);
-                browseRemotePath(parentPath);
-            } else {
-                updateLog("Could not navigate up from: " + currentRemotePath_);
-                 browseRemotePath("/"); // Go to root if cdUp fails strangely
-            }
-        } else {
-            QString newPath;
-            if (currentRemotePath_ == "/") {
-                newPath = "/" + itemName;
-            } else {
-                newPath = currentRemotePath_ + "/" + itemName;
-            }
-            // Clean path to remove any potential double slashes, though QDir::filePath or manual construction should be careful
-            newPath = QDir::cleanPath(newPath);
-            updateLog(QString("Navigating into directory: %1 (New path: %2)").arg(itemName, newPath));
-            browseRemotePath(newPath);
+  if (isDir) {
+    if (itemName == "..") {
+      QDir dir(currentRemotePath_);
+      if (dir.cdUp()) {
+        QString parentPath = dir.path();
+        // Ensure root path is just "/"
+        if (parentPath.isEmpty() || parentPath == "." || parentPath == "//") {
+          parentPath = "/";
         }
+        // QDir might return "/." for parent of "/foo", clean it.
+        if (parentPath.endsWith("/.")) {
+          parentPath = parentPath.left(parentPath.length() - 2);
+          if (parentPath.isEmpty())
+            parentPath = "/";
+        }
+        updateLog("Navigating up to: " + parentPath);
+        browseRemotePath(parentPath);
+      } else {
+        updateLog("Could not navigate up from: " + currentRemotePath_);
+        browseRemotePath("/"); // Go to root if cdUp fails strangely
+      }
     } else {
-        // Double-clicking a file could trigger download, view, etc.
-        // For now, let's call the download action.
-        updateLog(QString("Double-clicked file: %1. Triggering download.").arg(itemName));
-        onFileViewerDownloadClicked();
+      QString newPath;
+      if (currentRemotePath_ == "/") {
+        newPath = "/" + itemName;
+      } else {
+        newPath = currentRemotePath_ + "/" + itemName;
+      }
+      // Clean path to remove any potential double slashes, though
+      // QDir::filePath or manual construction should be careful
+      newPath = QDir::cleanPath(newPath);
+      updateLog(QString("Navigating into directory: %1 (New path: %2)")
+                    .arg(itemName, newPath));
+      browseRemotePath(newPath);
     }
+  } else {
+    // Double-clicking a file could trigger download, view, etc.
+    // For now, let's call the download action.
+    updateLog(
+        QString("Double-clicked file: %1. Triggering download.").arg(itemName));
+    onFileViewerDownloadClicked();
+  }
 }

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -18,6 +18,7 @@
 #include <QTextEdit>
 #include <QTimeEdit>
 #include <QTimer>
+#include <QScrollArea>
 // Forward declarations for Qt UI elements related to File Viewer
 QT_BEGIN_NAMESPACE
 class QTableWidget;
@@ -91,6 +92,8 @@ private:
   QPushButton *applyScheduleButton_;
   QPushButton *runBackupButton_;
   QTextEdit *logDisplay_;
+
+  QScrollArea *scrollArea_ = nullptr;
 
   // Backup Mode Selection
   QComboBox *backupModeComboBox_;

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -158,6 +158,8 @@ private:
 
   QString shortenPathForDisplay(const QString &path) const;
   QString currentDestinationForDisplay() const;
+
+  void adjustHeightToScreen();
 };
 
 #endif // MAINWINDOW_H

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -69,7 +69,6 @@ private slots:
   void onRemoveBackupTimeClicked();
 
   // Auto watch slots
-  void selectWatchDirectory();
   void onAutoWatchToggled(bool checked);
   void onDirectoryChanged(const QString &path);
   void onWatchTimerTimeout();
@@ -131,8 +130,6 @@ private:
   // Auto Watch UI
   QGroupBox *watchGroupBox_ = nullptr;
   QCheckBox *watchEnableCheckBox_ = nullptr;
-  QLineEdit *watchDirEdit_ = nullptr;
-  QPushButton *watchDirButton_ = nullptr;
   QLabel *watchStatusLabel_ = nullptr;
 
   QFileSystemWatcher *dirWatcher_ = nullptr;
@@ -155,6 +152,9 @@ private:
   // Remote File Viewer methods
   void displayRemoteFiles(const std::vector<FileMetadata> &files);
   void browseRemotePath(const QString &path);
+
+  QString shortenPathForDisplay(const QString &path) const;
+  QString currentDestinationForDisplay() const;
 };
 
 #endif // MAINWINDOW_H

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -5,18 +5,18 @@
 #include <QString>
 
 // Qt class includes
+#include <QCheckBox>
+#include <QComboBox>
+#include <QDockWidget>
+#include <QFileDialog>
+#include <QFileSystemWatcher>
+#include <QGroupBox>
+#include <QLabel> // Added for gcsAuthStatusLabel_
 #include <QLineEdit>
+#include <QListWidget>
 #include <QPushButton>
 #include <QTextEdit>
 #include <QTimeEdit>
-#include <QListWidget>
-#include <QFileDialog>
-#include <QComboBox>
-#include <QGroupBox>
-#include <QDockWidget>
-#include <QCheckBox>
-#include <QLabel> // Added for gcsAuthStatusLabel_
-#include <QFileSystemWatcher>
 #include <QTimer>
 // Forward declarations for Qt UI elements related to File Viewer
 QT_BEGIN_NAMESPACE
@@ -26,9 +26,9 @@ QT_END_NAMESPACE
 
 // Forward declaration for Scheduler
 class Scheduler;
+#include "core/IStorageTarget.h"    // For FileMetadata
 #include "util/CredentialManager.h" // For CredentialManager
-#include <memory> // For std::unique_ptr
-#include "core/IStorageTarget.h" // For FileMetadata
+#include <memory>                   // For std::unique_ptr
 
 // Forward declaration for Storage Targets
 class IStorageTarget;
@@ -37,122 +37,124 @@ class SftpTarget;
 class GcsTarget; // Forward declare GcsTarget
 
 class MainWindow : public QMainWindow {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent = nullptr);
-    ~MainWindow() override;
+  explicit MainWindow(QWidget *parent = nullptr);
+  ~MainWindow() override;
 
 protected:
-    void closeEvent(QCloseEvent *event) override;
+  void closeEvent(QCloseEvent *event) override;
 
 private slots:
-    void selectSourceDirectory();
-    void selectDestinationDirectory();
-    void applySchedule();
-    void runBackupNow();
-    void updateLog(const QString& message);
-    void onTaskChanged();
-    void onBackupModeChanged(int index);
-    void handleScheduledBackup(const QString& sourcePath, const QString& destinationOrIdentifier);
-    void onGcsConnectButtonClicked();
-    void onGcsTestConnectionClicked(); // Slot for GCS Test Connection
-    void onSftpConnectToggleClicked();
-    void onGcsConnectToggleClicked();
-    // Slots for File Viewer
-    void onFileViewerRefreshClicked();
-    void onFileViewerDownloadClicked();
-    void onFileViewerDeleteClicked();
-    void onFileTableItemDoubleClicked(QTableWidgetItem *item);
-    void onAddBackupTimeClicked();
-    void onRemoveBackupTimeClicked();
+  void selectSourceDirectory();
+  void selectDestinationDirectory();
+  void applySchedule();
+  void runBackupNow();
+  void updateLog(const QString &message);
+  void onTaskChanged();
+  void onBackupModeChanged(int index);
+  void handleScheduledBackup(const QString &sourcePath,
+                             const QString &destinationOrIdentifier);
+  void onGcsConnectButtonClicked();
+  void onGcsTestConnectionClicked(); // Slot for GCS Test Connection
+  void onSftpConnectToggleClicked();
+  void onGcsConnectToggleClicked();
+  // Slots for File Viewer
+  void onFileViewerRefreshClicked();
+  void onFileViewerDownloadClicked();
+  void onFileViewerDeleteClicked();
+  void onFileTableItemDoubleClicked(QTableWidgetItem *item);
+  void onAddBackupTimeClicked();
+  void onRemoveBackupTimeClicked();
 
-    // Auto watch slots
-    void selectWatchDirectory();
-    void onAutoWatchToggled(bool checked);
-    void onDirectoryChanged(const QString& path);
-    void onWatchTimerTimeout();
+  // Auto watch slots
+  void selectWatchDirectory();
+  void onAutoWatchToggled(bool checked);
+  void onDirectoryChanged(const QString &path);
+  void onWatchTimerTimeout();
 
 private:
-    void setupUI();
-    void loadSettings();
-    void saveSettings();
+  void setupUI();
+  void loadSettings();
+  void saveSettings();
 
-    // UI Elements
-    QLineEdit *sourceDirEdit_;
-    QPushButton *sourceDirButton_;
-    QLineEdit *destinationDirEdit_;
-    QPushButton *destinationDirButton_;
-    QTimeEdit *backupTimeEdit_;
-    QPushButton *addTimeButton_;
-    QListWidget *timeListWidget_;
-    QPushButton *removeTimeButton_;
-    QPushButton *applyScheduleButton_;
-    QPushButton *runBackupButton_;
-    QTextEdit *logDisplay_;
+  // UI Elements
+  QLineEdit *sourceDirEdit_;
+  QPushButton *sourceDirButton_;
+  QLineEdit *destinationDirEdit_;
+  QPushButton *destinationDirButton_;
+  QTimeEdit *backupTimeEdit_;
+  QList<QCheckBox *> dayCheckBoxes_;
+  QPushButton *addTimeButton_;
+  QListWidget *timeListWidget_;
+  QPushButton *removeTimeButton_;
+  QPushButton *applyScheduleButton_;
+  QPushButton *runBackupButton_;
+  QTextEdit *logDisplay_;
 
-    // Backup Mode Selection
-    QComboBox *backupModeComboBox_;
+  // Backup Mode Selection
+  QComboBox *backupModeComboBox_;
 
-    // Local Backup Settings
-    QGroupBox *m_localDestinationGroupBox;
+  // Local Backup Settings
+  QGroupBox *m_localDestinationGroupBox;
 
-    // SFTP Settings
-    QGroupBox *sftpSettingsGroupBox_;
-    QLineEdit *sftpHostLineEdit_;
-    QLineEdit *sftpPortLineEdit_;
-    QLineEdit *sftpUsernameLineEdit_;
-    QLineEdit *sftpPasswordLineEdit_;
-    QLineEdit *sftpRemotePathLineEdit_;
-    QCheckBox *sftpSavePasswordCheckBox_;
-    QPushButton *sftpConnectToggleButton_{nullptr};
+  // SFTP Settings
+  QGroupBox *sftpSettingsGroupBox_;
+  QLineEdit *sftpHostLineEdit_;
+  QLineEdit *sftpPortLineEdit_;
+  QLineEdit *sftpUsernameLineEdit_;
+  QLineEdit *sftpPasswordLineEdit_;
+  QLineEdit *sftpRemotePathLineEdit_;
+  QCheckBox *sftpSavePasswordCheckBox_;
+  QPushButton *sftpConnectToggleButton_{nullptr};
 
-    // GCS Settings
-    QGroupBox *gcsSettingsGroupBox_;
-    QLineEdit *gcsBucketNameLineEdit_;
-    QLineEdit *gcsAccountIdentifierLineEdit_;
-    QPushButton *gcsConnectButton_;
-    QPushButton *gcsTestConnectionButton_; // Added
-    QLabel *gcsAuthStatusLabel_;
-    QPushButton *gcsConnectToggleButton_{nullptr};
+  // GCS Settings
+  QGroupBox *gcsSettingsGroupBox_;
+  QLineEdit *gcsBucketNameLineEdit_;
+  QLineEdit *gcsAccountIdentifierLineEdit_;
+  QPushButton *gcsConnectButton_;
+  QPushButton *gcsTestConnectionButton_; // Added
+  QLabel *gcsAuthStatusLabel_;
+  QPushButton *gcsConnectToggleButton_{nullptr};
 
-    // File Viewer UI Elements
-    QGroupBox *fileViewerGroupBox_ = nullptr;
-    QDockWidget *fileViewerDockWidget_ = nullptr;
-    QTableWidget *fileTableWidget_ = nullptr;
-    QPushButton *refreshButton_ = nullptr;
-    QPushButton *downloadButton_ = nullptr;
-    QPushButton *deleteButton_ = nullptr;
-    QLabel *currentPathLabel_ = nullptr;
-    QString currentRemotePath_ = "/";
+  // File Viewer UI Elements
+  QGroupBox *fileViewerGroupBox_ = nullptr;
+  QDockWidget *fileViewerDockWidget_ = nullptr;
+  QTableWidget *fileTableWidget_ = nullptr;
+  QPushButton *refreshButton_ = nullptr;
+  QPushButton *downloadButton_ = nullptr;
+  QPushButton *deleteButton_ = nullptr;
+  QLabel *currentPathLabel_ = nullptr;
+  QString currentRemotePath_ = "/";
 
-    // Auto Watch UI
-    QGroupBox *watchGroupBox_ = nullptr;
-    QCheckBox *watchEnableCheckBox_ = nullptr;
-    QLineEdit *watchDirEdit_ = nullptr;
-    QPushButton *watchDirButton_ = nullptr;
-    QLabel *watchStatusLabel_ = nullptr;
+  // Auto Watch UI
+  QGroupBox *watchGroupBox_ = nullptr;
+  QCheckBox *watchEnableCheckBox_ = nullptr;
+  QLineEdit *watchDirEdit_ = nullptr;
+  QPushButton *watchDirButton_ = nullptr;
+  QLabel *watchStatusLabel_ = nullptr;
 
-    QFileSystemWatcher *dirWatcher_ = nullptr;
-    QTimer *watchTriggerTimer_ = nullptr;
+  QFileSystemWatcher *dirWatcher_ = nullptr;
+  QTimer *watchTriggerTimer_ = nullptr;
 
-    // Core components
-    Scheduler *scheduler_;
-    LocalTarget *localTarget_; 
-    SftpTarget *sftpTarget_;
-    GcsTarget *gcsTarget_; // GCS Target instance
+  // Core components
+  Scheduler *scheduler_;
+  LocalTarget *localTarget_;
+  SftpTarget *sftpTarget_;
+  GcsTarget *gcsTarget_; // GCS Target instance
 
-    std::unique_ptr<CredentialManager> m_credentialManager;
+  std::unique_ptr<CredentialManager> m_credentialManager;
 
-    // Helper for file dialogs
-    QFileDialog *fileDialog_;
+  // Helper for file dialogs
+  QFileDialog *fileDialog_;
 
-    // Internal helper to perform the backup logic
-    void performBackupInternal(const QString& sourcePath, IStorageTarget* target);
+  // Internal helper to perform the backup logic
+  void performBackupInternal(const QString &sourcePath, IStorageTarget *target);
 
-    // Remote File Viewer methods
-    void displayRemoteFiles(const std::vector<FileMetadata>& files);
-    void browseRemotePath(const QString& path);
+  // Remote File Viewer methods
+  void displayRemoteFiles(const std::vector<FileMetadata> &files);
+  void browseRemotePath(const QString &path);
 };
 
 #endif // MAINWINDOW_H

--- a/backy_x/tests/test_scheduler.cpp
+++ b/backy_x/tests/test_scheduler.cpp
@@ -1,182 +1,202 @@
-#include "gtest/gtest.h"
 #include "core/Scheduler.h" // Adjust path as necessary
+#include "gtest/gtest.h"
 #include <QCoreApplication> // Required by Qt classes, even in tests
-#include <QTemporaryFile>   // To create a temporary settings file
-#include <QSignalSpy>       // For testing signals
 #include <QFile>            // For QFile::remove
+#include <QSignalSpy>       // For testing signals
+#include <QTemporaryFile>   // To create a temporary settings file
 
 // Test fixture for Scheduler tests
 class SchedulerTest : public ::testing::Test {
 protected:
-    QTemporaryFile tempSettingsFile_; // Will provide a unique temporary file name
-    Scheduler* scheduler_;
-    
-    // We need a QCoreApplication instance for QSettings and QTimer to work.
-    // GTest doesn't run a Qt event loop by default.
-    // For tests involving QTimer, more advanced setup (QEventLoop) might be needed.
-    // For now, focus on QSettings and property logic.
-    static QCoreApplication* appInstance;
-    static int argc_ ; // Dummy argc
-    static char* argv_[]; // Dummy argv
+  QTemporaryFile tempSettingsFile_; // Will provide a unique temporary file name
+  Scheduler *scheduler_;
+
+  // We need a QCoreApplication instance for QSettings and QTimer to work.
+  // GTest doesn't run a Qt event loop by default.
+  // For tests involving QTimer, more advanced setup (QEventLoop) might be
+  // needed. For now, focus on QSettings and property logic.
+  static QCoreApplication *appInstance;
+  static int argc_;     // Dummy argc
+  static char *argv_[]; // Dummy argv
 
 public:
-    static void SetUpTestSuite() {
-        // Create a QCoreApplication instance once for all tests in this suite
-        // This is necessary for QSettings to function correctly, especially if not using a specific file path initially.
-        // And for QObject-based classes like QTimer.
-        if (!QCoreApplication::instance()) {
-            // For tests, ensure argc_ is at least 1 and argv_[0] is a valid string if QCoreApplication uses them.
-            // Simplified for GTest: often just 0 and nullptr are fine if not parsing actual command line.
-            // However, some Qt versions might require a valid argv[0].
-            static char app_name[] = "SchedulerTest"; // Dummy app name
-            argc_ = 1; 
-            argv_[0] = app_name; // Provide a dummy app name
-            argv_[1] = nullptr; // Null-terminate argv
+  static void SetUpTestSuite() {
+    // Create a QCoreApplication instance once for all tests in this suite
+    // This is necessary for QSettings to function correctly, especially if not
+    // using a specific file path initially. And for QObject-based classes like
+    // QTimer.
+    if (!QCoreApplication::instance()) {
+      // For tests, ensure argc_ is at least 1 and argv_[0] is a valid string if
+      // QCoreApplication uses them. Simplified for GTest: often just 0 and
+      // nullptr are fine if not parsing actual command line. However, some Qt
+      // versions might require a valid argv[0].
+      static char app_name[] = "SchedulerTest"; // Dummy app name
+      argc_ = 1;
+      argv_[0] = app_name; // Provide a dummy app name
+      argv_[1] = nullptr;  // Null-terminate argv
 
-            appInstance = new QCoreApplication(argc_, argv_);
-            // Use specific names for testing to avoid interfering with user's actual app settings
-            QCoreApplication::setOrganizationName("BackyFullTestOrg");
-            QCoreApplication::setApplicationName("BackyFullTestApp");
-        }
+      appInstance = new QCoreApplication(argc_, argv_);
+      // Use specific names for testing to avoid interfering with user's actual
+      // app settings
+      QCoreApplication::setOrganizationName("BackyFullTestOrg");
+      QCoreApplication::setApplicationName("BackyFullTestApp");
     }
+  }
 
-    static void TearDownTestSuite() {
-        delete appInstance;
-        appInstance = nullptr;
-    }
+  static void TearDownTestSuite() {
+    delete appInstance;
+    appInstance = nullptr;
+  }
 
 protected:
-    void SetUp() override {
-        // Open the temporary file to get its name, then close it.
-        // QSettings will create/overwrite it.
-        ASSERT_TRUE(tempSettingsFile_.open());
-        QString settingsFilePath = tempSettingsFile_.fileName();
-        tempSettingsFile_.close(); // QSettings will manage the file itself.
+  void SetUp() override {
+    // Open the temporary file to get its name, then close it.
+    // QSettings will create/overwrite it.
+    ASSERT_TRUE(tempSettingsFile_.open());
+    QString settingsFilePath = tempSettingsFile_.fileName();
+    tempSettingsFile_.close(); // QSettings will manage the file itself.
 
-        scheduler_ = new Scheduler(settingsFilePath); // Pass temp file path
-    }
+    scheduler_ = new Scheduler(settingsFilePath); // Pass temp file path
+  }
 
-    void TearDown() override {
-        delete scheduler_;
-        scheduler_ = nullptr;
-        // QTemporaryFile will delete the file when it goes out of scope if it still exists.
-        // To be absolutely sure it's gone for the next test (if it was recreated by QSettings):
-        QFile::remove(tempSettingsFile_.fileName());
-    }
+  void TearDown() override {
+    delete scheduler_;
+    scheduler_ = nullptr;
+    // QTemporaryFile will delete the file when it goes out of scope if it still
+    // exists. To be absolutely sure it's gone for the next test (if it was
+    // recreated by QSettings):
+    QFile::remove(tempSettingsFile_.fileName());
+  }
 };
 
 // Initialize static members
-QCoreApplication* SchedulerTest::appInstance = nullptr;
+QCoreApplication *SchedulerTest::appInstance = nullptr;
 // Ensure argc_ and argv_ are defined.
-// For safety, initialize argv_ to point to a char array that can hold at least one string + nullptr.
-// Or, if QCoreApplication only needs argc=0, argv=nullptr, that's simpler.
-// Let's refine based on common practice: minimal argc/argv for QCoreApplication if not parsing.
-int SchedulerTest::argc_ = 0; 
-char* SchedulerTest::argv_[] = { nullptr };
-
+// For safety, initialize argv_ to point to a char array that can hold at least
+// one string + nullptr. Or, if QCoreApplication only needs argc=0,
+// argv=nullptr, that's simpler. Let's refine based on common practice: minimal
+// argc/argv for QCoreApplication if not parsing.
+int SchedulerTest::argc_ = 0;
+char *SchedulerTest::argv_[] = {nullptr};
 
 TEST_F(SchedulerTest, InitialState) {
-    // Scheduler loads task on construction.
-    // Default task (if settings file is new/empty) should be:
-    // - Empty source/destination paths
-    // - Default time (e.g., 23:00)
-    // - Disabled
-    EXPECT_EQ(scheduler_->sourcePath(), QString(""));
-    EXPECT_EQ(scheduler_->destinationPath(), QString(""));
-    ASSERT_EQ(scheduler_->scheduledTimes().size(), 1);
-    EXPECT_EQ(scheduler_->scheduledTimes().first(), QTime(23, 0));
-    EXPECT_FALSE(scheduler_->isEnabled());
+  // Scheduler loads task on construction.
+  // Default task (if settings file is new/empty) should be:
+  // - Empty source/destination paths
+  // - Default time (e.g., 23:00)
+  // - Disabled
+  EXPECT_EQ(scheduler_->sourcePath(), QString(""));
+  EXPECT_EQ(scheduler_->destinationPath(), QString(""));
+  ASSERT_EQ(scheduler_->scheduledTimes().size(), 1);
+  EXPECT_EQ(scheduler_->scheduledTimes().first(), QTime(23, 0));
+  EXPECT_FALSE(scheduler_->isEnabled());
 }
 
 TEST_F(SchedulerTest, SetAndGetTaskProperties) {
-    QString src = "/test/source";
-    QString dst = "/test/destination";
-    QTime time(10, 30);
-    bool enabled = true;
+  QString src = "/test/source";
+  QString dst = "/test/destination";
+  QTime time(10, 30);
+  ScheduleEntry se{time, {}};
+  bool enabled = true;
 
-    QSignalSpy taskChangedSpy(scheduler_, &Scheduler::taskChanged);
+  QSignalSpy taskChangedSpy(scheduler_, &Scheduler::taskChanged);
 
-    scheduler_->setDailyBackupTask(src, dst, QList<QTime>{time}, enabled, false, QString(), 0, QString(), QString());
+  scheduler_->setDailyBackupTask(src, dst, QList<ScheduleEntry>{se}, enabled,
+                                 false, QString(), 0, QString(), QString());
 
-    EXPECT_EQ(scheduler_->sourcePath(), src);
-    EXPECT_EQ(scheduler_->destinationPath(), dst);
-    ASSERT_EQ(scheduler_->scheduledTimes().size(), 1);
-    EXPECT_EQ(scheduler_->scheduledTimes().first(), time);
-    EXPECT_EQ(scheduler_->isEnabled(), enabled);
-    ASSERT_GE(taskChangedSpy.count(), 1); // taskChanged should be emitted at least once
-                                         // (could be twice if loadTask also emits and changes state)
-                                         // Let's assume setDailyBackupTask is the primary emitter here.
-                                         // If loadTask always emits, this might need adjustment or specific spy setup.
-                                         // For this test, 1 emission directly from setDailyBackupTask is key.
-    // To be more precise if loadTask always emits:
-    // taskChangedSpy.clear(); // Clear any emissions from loadTask during setup
-    // scheduler_->setDailyBackupTask(src, dst, time, enabled);
-    // EXPECT_EQ(taskChangedSpy.count(), 1); 
-    // For simplicity, assuming current Scheduler logic where loadTask might emit,
-    // and setDailyBackupTask also emits. The test as is checks if *a* change happened.
-    // If setDailyBackupTask itself guarantees one emission, this is fine.
+  EXPECT_EQ(scheduler_->sourcePath(), src);
+  EXPECT_EQ(scheduler_->destinationPath(), dst);
+  ASSERT_EQ(scheduler_->scheduleEntries().size(), 1);
+  EXPECT_EQ(scheduler_->scheduleEntries().first().time, time);
+  EXPECT_EQ(scheduler_->isEnabled(), enabled);
+  ASSERT_GE(taskChangedSpy.count(),
+            1); // taskChanged should be emitted at least once
+                // (could be twice if loadTask also emits and changes state)
+                // Let's assume setDailyBackupTask is the primary emitter here.
+                // If loadTask always emits, this might need adjustment or
+                // specific spy setup. For this test, 1 emission directly from
+                // setDailyBackupTask is key.
+  // To be more precise if loadTask always emits:
+  // taskChangedSpy.clear(); // Clear any emissions from loadTask during setup
+  // scheduler_->setDailyBackupTask(src, dst, time, enabled);
+  // EXPECT_EQ(taskChangedSpy.count(), 1);
+  // For simplicity, assuming current Scheduler logic where loadTask might emit,
+  // and setDailyBackupTask also emits. The test as is checks if *a* change
+  // happened. If setDailyBackupTask itself guarantees one emission, this is
+  // fine.
 }
 
 TEST_F(SchedulerTest, SaveAndLoadTask) {
-    QString src = "/another/source";
-    QString dst = "/another/destination";
-    QTime time(14, 45);
-    bool enabled = true;
+  QString src = "/another/source";
+  QString dst = "/another/destination";
+  QTime time(14, 45);
+  ScheduleEntry se{time, {}};
+  bool enabled = true;
 
-    scheduler_->setDailyBackupTask(src, dst, QList<QTime>{time}, enabled, false, QString(), 0, QString(), QString());
-    // Task is saved by setDailyBackupTask.
+  scheduler_->setDailyBackupTask(src, dst, QList<ScheduleEntry>{se}, enabled,
+                                 false, QString(), 0, QString(), QString());
+  // Task is saved by setDailyBackupTask.
 
-    // Create a new Scheduler instance using the same settings file
-    // to verify persistence.
-    Scheduler scheduler2(tempSettingsFile_.fileName());
+  // Create a new Scheduler instance using the same settings file
+  // to verify persistence.
+  Scheduler scheduler2(tempSettingsFile_.fileName());
 
-    EXPECT_EQ(scheduler2.sourcePath(), src);
-    EXPECT_EQ(scheduler2.destinationPath(), dst);
-    ASSERT_EQ(scheduler2.scheduledTimes().size(), 1);
-    EXPECT_EQ(scheduler2.scheduledTimes().first(), time);
-    EXPECT_EQ(scheduler2.isEnabled(), enabled);
+  EXPECT_EQ(scheduler2.sourcePath(), src);
+  EXPECT_EQ(scheduler2.destinationPath(), dst);
+  ASSERT_EQ(scheduler2.scheduleEntries().size(), 1);
+  EXPECT_EQ(scheduler2.scheduleEntries().first().time, time);
+  EXPECT_EQ(scheduler2.isEnabled(), enabled);
 }
 
 TEST_F(SchedulerTest, DisableTask) {
-    QString src = "/path/src";
-    QString dst = "/path/dst";
-    QTime time(12, 00);
+  QString src = "/path/src";
+  QString dst = "/path/dst";
+  QTime time(12, 00);
+  ScheduleEntry se{time, {}};
 
-    scheduler_->setDailyBackupTask(src, dst, QList<QTime>{time}, true, false, QString(), 0, QString(), QString()); // Enable first
-    ASSERT_TRUE(scheduler_->isEnabled());
+  scheduler_->setDailyBackupTask(src, dst, QList<ScheduleEntry>{se}, true,
+                                 false, QString(), 0, QString(),
+                                 QString()); // Enable first
+  ASSERT_TRUE(scheduler_->isEnabled());
 
-    scheduler_->setDailyBackupTask(src, dst, QList<QTime>{time}, false, false, QString(), 0, QString(), QString()); // Then disable
-    EXPECT_FALSE(scheduler_->isEnabled());
+  scheduler_->setDailyBackupTask(src, dst, QList<ScheduleEntry>{se}, false,
+                                 false, QString(), 0, QString(),
+                                 QString()); // Then disable
+  EXPECT_FALSE(scheduler_->isEnabled());
 
-    // Verify persistence of disabled state
-    Scheduler scheduler2(tempSettingsFile_.fileName());
-    EXPECT_FALSE(scheduler2.isEnabled());
-    EXPECT_EQ(scheduler2.sourcePath(), src); // Other params should still be there
+  // Verify persistence of disabled state
+  Scheduler scheduler2(tempSettingsFile_.fileName());
+  EXPECT_FALSE(scheduler2.isEnabled());
+  EXPECT_EQ(scheduler2.sourcePath(), src); // Other params should still be there
 }
 
 TEST_F(SchedulerTest, HandlesEmptyPathsOnSet) {
-    // Setting empty paths should be stored as such
-    scheduler_->setDailyBackupTask("", "", QList<QTime>{QTime(1,1)}, true, false, QString(), 0, QString(), QString());
-    EXPECT_EQ(scheduler_->sourcePath(), QString(""));
-    EXPECT_EQ(scheduler_->destinationPath(), QString(""));
+  // Setting empty paths should be stored as such
+  ScheduleEntry se{QTime(1, 1), {}};
+  scheduler_->setDailyBackupTask("", "", QList<ScheduleEntry>{se}, true, false,
+                                 QString(), 0, QString(), QString());
+  EXPECT_EQ(scheduler_->sourcePath(), QString(""));
+  EXPECT_EQ(scheduler_->destinationPath(), QString(""));
 
-    Scheduler scheduler2(tempSettingsFile_.fileName());
-    EXPECT_EQ(scheduler2.sourcePath(), QString(""));
-    EXPECT_EQ(scheduler2.destinationPath(), QString(""));
+  Scheduler scheduler2(tempSettingsFile_.fileName());
+  EXPECT_EQ(scheduler2.sourcePath(), QString(""));
+  EXPECT_EQ(scheduler2.destinationPath(), QString(""));
 }
 
-// Note: Testing QTimer-based signal emission (backupTaskTriggered) is more complex
-// as it requires an active event loop and control over time.
-// This might involve QTestLib or more intricate QEventLoop spinning in tests.
-// For M1, focusing on state/QSettings is a good start.
+// Note: Testing QTimer-based signal emission (backupTaskTriggered) is more
+// complex as it requires an active event loop and control over time. This might
+// involve QTestLib or more intricate QEventLoop spinning in tests. For M1,
+// focusing on state/QSettings is a good start.
 
-// Example of a placeholder for timer test (would likely fail or hang without event loop)
+// Example of a placeholder for timer test (would likely fail or hang without
+// event loop)
 /*
 #include <QtTest/QTest> // For QTest::qWait, if using QTestLib features
 
 TEST_F(SchedulerTest, DISABLED_BackupSignalEmission) {
     if (!qgetenv("CI").isEmpty()) { // Or some other way to detect CI
-        GTEST_SKIP() << "Skipping timer test in CI environment without full Qt event loop setup.";
+        GTEST_SKIP() << "Skipping timer test in CI environment without full Qt
+event loop setup.";
     }
 
     QSignalSpy spy(scheduler_, &Scheduler::backupTaskTriggered);
@@ -184,23 +204,27 @@ TEST_F(SchedulerTest, DISABLED_BackupSignalEmission) {
     QString dst = "/test/dest_signal";
     // Schedule for a very short time in the future
     // QTime scheduledTime = QTime::currentTime().addMSecs(200); // 200 ms
-    // For more reliability, schedule for a slightly longer, fixed time from a known point
-    // or mock QDateTime::currentDateTime() if possible (hard without a dedicated mocking framework for Qt types).
+    // For more reliability, schedule for a slightly longer, fixed time from a
+known point
+    // or mock QDateTime::currentDateTime() if possible (hard without a
+dedicated mocking framework for Qt types).
     // Let's assume test runs reasonably fast.
-    
-    // Need to ensure the event loop runs. This is tricky with GTest alone.
-    // If QCoreApplication is running, events might be processed, but timers need active processing.
-    
-    // This part is highly dependent on the test runner and Qt integration.
-    // A simple QTest::qWait might work if QTEST_MAIN is used or similar context is set up.
-    // QTest::qWait(300); 
 
-    // Alternative using QEventLoop (more GTest-idiomatic if not using QTestLib's runner):
-    QEventLoop loop;
-    QTimer checkTimer; // Timer to periodically check spy or exit loop
-    int maxWaitLoops = 10; // Max 1 second wait (10 * 100ms)
-    
-    scheduler_->setDailyBackupTask(src, dst, QTime::currentTime().addMSecs(50), true); // Schedule very soon
+    // Need to ensure the event loop runs. This is tricky with GTest alone.
+    // If QCoreApplication is running, events might be processed, but timers
+need active processing.
+
+    // This part is highly dependent on the test runner and Qt integration.
+    // A simple QTest::qWait might work if QTEST_MAIN is used or similar context
+is set up.
+    // QTest::qWait(300);
+
+    // Alternative using QEventLoop (more GTest-idiomatic if not using
+QTestLib's runner): QEventLoop loop; QTimer checkTimer; // Timer to periodically
+check spy or exit loop int maxWaitLoops = 10; // Max 1 second wait (10 * 100ms)
+
+    scheduler_->setDailyBackupTask(src, dst, QTime::currentTime().addMSecs(50),
+true); // Schedule very soon
 
     QObject::connect(&checkTimer, &QTimer::timeout, [&]() {
         if (spy.count() > 0 || maxWaitLoops-- <= 0) {
@@ -221,9 +245,9 @@ TEST_F(SchedulerTest, DISABLED_BackupSignalEmission) {
 }
 */
 
-// It's good practice to have a main for test executables if not using a global test runner from CMake.
-// However, CMake with GTest usually handles this.
-// For Qt tests, especially those needing an event loop, QTEST_MAIN or a custom main
+// It's good practice to have a main for test executables if not using a global
+// test runner from CMake. However, CMake with GTest usually handles this. For
+// Qt tests, especially those needing an event loop, QTEST_MAIN or a custom main
 // with QApplication might be needed.
-// For now, this structure assumes basic GTest execution. If timer tests are added,
-// the test execution setup might need QTestLib integration.
+// For now, this structure assumes basic GTest execution. If timer tests are
+// added, the test execution setup might need QTestLib integration.


### PR DESCRIPTION
## Summary
- extend Scheduler to store days of week for each time
- persist new format while staying backward compatible
- update MainWindow UI to choose days when adding schedule
- adjust logic to trigger backups only on allowed days
- update unit tests for new ScheduleEntry API

## Testing
- `cmake ..` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684055217ff0832183b5f4318a0af15e