### PR TITLE
Improve SFTP validation and LocalTarget tests

### DIFF
--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -20,6 +20,7 @@
 #include <QHBoxLayout>
 #include <QToolButton>
 #include <QLabel>
+#include <QIntValidator>
 #include <QScreen>
 #include <QMessageBox>
 #include <QSettings>
@@ -159,168 +160,14 @@ void MainWindow::setupUI() {
   modeLayout->addStretch();
   mainLayout->addWidget(headerFrame);
 
-  QGroupBox *sourceGroupBox = new QGroupBox(tr("Source Configuration"));
-  sourceGroupBox->setStyleSheet("background:#fafafa; border:1px solid #ddd;");
-  QFormLayout *sourceLayout = new QFormLayout(sourceGroupBox);
-  QHBoxLayout *srcPathLayout = new QHBoxLayout();
-  sourceDirEdit_ = new QLineEdit();
-  sourceDirEdit_->setReadOnly(true);
-  srcPathLayout->addWidget(sourceDirEdit_);
-  sourceDirButton_ = new QPushButton(tr("Browse..."));
-  sourceDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
-  sourceDirButton_->setStyleSheet(buttonStyle);
-  srcPathLayout->addWidget(sourceDirButton_);
-  connect(sourceDirButton_, &QPushButton::clicked, this,
-          &MainWindow::selectSourceDirectory);
-  sourceLayout->addRow(tr("Source Directory:"), srcPathLayout);
-  QLabel *sourceHint = new QLabel(tr("Select the folder to back up"));
-  sourceHint->setStyleSheet("color: gray; font-style: italic;");
-  sourceLayout->addRow(sourceHint);
-
-  watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
-  QHBoxLayout *watchLayout = new QHBoxLayout(watchGroupBox_);
-  watchToggleCheckBox_ = new QCheckBox(tr("Enable monitoring"));
-  watchLayout->addWidget(watchToggleCheckBox_);
-  watchStatusLabel_ = new QLabel(tr("Monitoring off"));
-  watchStatusLabel_->setStyleSheet("color:#2680eb;");
-  watchLayout->addWidget(watchStatusLabel_);
-  watchLayout->addStretch();
-  connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
-          &MainWindow::onWatchToggleChanged);
-  sourceLayout->addRow(watchGroupBox_);
-  mainLayout->addWidget(sourceGroupBox);
-
-  m_localDestinationGroupBox =
-      new QGroupBox(tr("Local Destination Configuration"));
-  m_localDestinationGroupBox->setStyleSheet("background:#fafafa; border:1px solid #ddd;");
-  QFormLayout *localDestLayout = new QFormLayout(m_localDestinationGroupBox);
-  QHBoxLayout *destPathLayout = new QHBoxLayout();
-  destinationDirEdit_ = new QLineEdit();
-  destinationDirEdit_->setReadOnly(true);
-  destPathLayout->addWidget(destinationDirEdit_);
-  destinationDirButton_ = new QPushButton(tr("Browse..."));
-  destinationDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
-  destinationDirButton_->setStyleSheet(buttonStyle);
-  destPathLayout->addWidget(destinationDirButton_);
-  connect(destinationDirButton_, &QPushButton::clicked, this,
-          &MainWindow::selectDestinationDirectory);
-  localDestLayout->addRow(tr("Destination Directory (Local):"), destPathLayout);
-  QLabel *destHint = new QLabel(tr("Select destination folder (local or remote)"));
-  destHint->setStyleSheet("color: gray; font-style: italic;");
-  localDestLayout->addRow(destHint);
-  mainLayout->addWidget(m_localDestinationGroupBox);
-
-  sftpSettingsGroupBox_ = new QGroupBox(tr("SFTP Configuration"));
-  QFormLayout *sftpFormLayout = new QFormLayout(sftpSettingsGroupBox_);
-  sftpHostLineEdit_ = new QLineEdit();
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Host:")), sftpHostLineEdit_);
-  sftpPortLineEdit_ = new QLineEdit();
-  sftpPortLineEdit_->setText("22");
-  sftpPortLineEdit_->setValidator(new QIntValidator(1, 65535, this));
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Port:")), sftpPortLineEdit_);
-  sftpUsernameLineEdit_ = new QLineEdit();
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Username:")),
-                         sftpUsernameLineEdit_);
-  sftpPasswordLineEdit_ = new QLineEdit();
-  sftpPasswordLineEdit_->setEchoMode(QLineEdit::Password);
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Password:")),
-                         sftpPasswordLineEdit_);
-  sftpSavePasswordCheckBox_ = new QCheckBox(tr("Save password securely"));
-  sftpFormLayout->addRow(sftpSavePasswordCheckBox_);
-  sftpRemotePathLineEdit_ = new QLineEdit();
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Remote Path:")),
-                         sftpRemotePathLineEdit_);
-  sftpConnectToggleButton_ = new QPushButton(tr("Connect"));
-  sftpConnectToggleButton_->setStyleSheet(buttonStyle);
-  sftpFormLayout->addRow(sftpConnectToggleButton_);
-  connect(sftpConnectToggleButton_, &QPushButton::clicked, this,
-          &MainWindow::onSftpConnectToggleClicked);
-  mainLayout->addWidget(sftpSettingsGroupBox_);
-
-  gcsSettingsGroupBox_ =
-      new QGroupBox(tr("Google Cloud Storage Configuration"));
-  QFormLayout *gcsFormLayout = new QFormLayout(gcsSettingsGroupBox_);
-  gcsBucketNameLineEdit_ = new QLineEdit();
-  gcsBucketNameLineEdit_->setToolTip(tr("Name of your GCS bucket (must exist)"));
-  gcsFormLayout->addRow(new QLabel(tr("GCS Bucket Name:")),
-                        gcsBucketNameLineEdit_);
-  gcsAccountIdentifierLineEdit_ = new QLineEdit();
-  gcsAccountIdentifierLineEdit_->setToolTip(tr("Email linked to your Google account"));
-  gcsFormLayout->addRow(new QLabel(tr("GCS Account Identifier:")),
-                        gcsAccountIdentifierLineEdit_);
-  gcsConnectButton_ = new QPushButton(tr("Log in to Google Drive"));
-  gcsConnectButton_->setStyleSheet(buttonStyle);
-  gcsFormLayout->addRow(gcsConnectButton_);
-  connect(gcsConnectButton_, &QPushButton::clicked, this,
-          &MainWindow::onGcsConnectButtonClicked);
-  gcsAuthStatusLabel_ = new QLabel(tr("Status: Not Authenticated"));
-  gcsFormLayout->addRow(gcsAuthStatusLabel_);
-  gcsTestConnectionButton_ =
-      new QPushButton(tr("Test Connection")); // Instantiate and add
-  gcsTestConnectionButton_->setStyleSheet(buttonStyle);
-  gcsFormLayout->addRow(gcsTestConnectionButton_);
-  connect(gcsTestConnectionButton_, &QPushButton::clicked, this,
-          &MainWindow::onGcsTestConnectionClicked);
-  gcsConnectToggleButton_ =
-      new QPushButton(tr("Connect")); // For listing session
-  gcsConnectToggleButton_->setStyleSheet(buttonStyle);
-  gcsFormLayout->addRow(gcsConnectToggleButton_);
-  connect(gcsConnectToggleButton_, &QPushButton::clicked, this,
-          &MainWindow::onGcsConnectToggleClicked);
-  mainLayout->addWidget(gcsSettingsGroupBox_);
+  createSourceConfigUI(mainLayout, buttonStyle);
 
   connect(backupModeComboBox_,
           QOverload<int>::of(&QComboBox::currentIndexChanged), this,
           &MainWindow::onBackupModeChanged);
 
-  QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Controls"));
-  scheduleGroupBox->setStyleSheet("background:#fafafa; border:1px solid #ddd;");
-  QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
-  scheduleLayout->addWidget(new QLabel(tr("Backup Time:")), 0, 0);
-  backupTimeEdit_ = new QTimeEdit();
-  backupTimeEdit_->setDisplayFormat("HH:mm");
-  QHBoxLayout *scheduleRow = new QHBoxLayout();
-  scheduleRow->setSpacing(6);
-  const QStringList dayLabels = {"M", "T", "W", "T", "F", "S", "S"};
-  for (int i = 0; i < 7; ++i) {
-    QToolButton *btn = new QToolButton();
-    btn->setText(dayLabels[i]);
-    btn->setCheckable(true);
-    btn->setFixedSize(26, 26);
-    btn->setStyleSheet("QToolButton{border-radius:13px;border:1px solid gray;background:#f0f0f0;}QToolButton:checked{background:#2680eb;color:white;}");
-    dayButtons_.append(btn);
-    scheduleRow->addWidget(btn);
-  }
-  scheduleRow->addWidget(backupTimeEdit_);
-  addTimeButton_ = new QToolButton();
-  addTimeButton_->setText("+");
-  addTimeButton_->setFixedSize(26,26);
-  addTimeButton_->setStyleSheet("QToolButton{border-radius:13px;border:1px solid gray;background:#e0e0e0;}");
-  scheduleRow->addWidget(addTimeButton_);
-  scheduleLayout->addLayout(scheduleRow, 0, 0, 1, 3);
-  connect(addTimeButton_, &QToolButton::clicked, this,
-          &MainWindow::onAddBackupTimeClicked);
+  createSchedulingControlsUI(mainLayout, buttonStyle);
 
-  scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 1, 0, 1, 3);
-  timeListWidget_ = new QListWidget();
-  QFrame *timesFrame = new QFrame();
-  timesFrame->setStyleSheet("background:#f0f0f0;border:1px solid #ccc;");
-  QVBoxLayout *timesLayout = new QVBoxLayout(timesFrame);
-  timesLayout->setContentsMargins(0,0,0,0);
-  timesLayout->addWidget(timeListWidget_);
-  scheduleLayout->addWidget(timesFrame, 2, 0, 1, 3);
-  removeTimeButton_ = new QPushButton(tr("Remove Selected"));
-  removeTimeButton_->setStyleSheet(buttonStyle);
-  scheduleLayout->addWidget(removeTimeButton_, 3, 0, 1, 3);
-  connect(removeTimeButton_, &QPushButton::clicked, this,
-          &MainWindow::onRemoveBackupTimeClicked);
-
-  runBackupButton_ = new QPushButton(tr("Run Backup Now"));
-  runBackupButton_->setStyleSheet(buttonStyle);
-  connect(runBackupButton_, &QPushButton::clicked, this,
-          &MainWindow::runBackupNow);
-  scheduleLayout->addWidget(runBackupButton_, 4, 0, 1, 3, Qt::AlignCenter);
-  mainLayout->addWidget(scheduleGroupBox);
 
   QToolButton *logToggleButton = new QToolButton();
   logToggleButton->setText(tr("Logs"));
@@ -381,6 +228,7 @@ void MainWindow::setupUI() {
 
   fileViewerDockWidget_ = new QDockWidget(tr("Remote File Browser"), this);
   fileViewerDockWidget_->setWidget(fileViewerGroupBox_);
+  fileViewerDockWidget_->setMinimumSize(250, 300);
   addDockWidget(Qt::RightDockWidgetArea, fileViewerDockWidget_);
   fileViewerDockWidget_->hide();
   viewMenu->addAction(fileViewerDockWidget_->toggleViewAction());
@@ -2313,4 +2161,198 @@ void MainWindow::adjustHeightToScreen() {
   adjustSize();
   if (height() > avail)
     resize(width(), avail);
+}
+
+void MainWindow::applyUnifiedStyle(QWidget *widget) {
+  if (!widget)
+    return;
+  if (auto layout = widget->layout()) {
+    layout->setContentsMargins(8, 8, 8, 8);
+    layout->setSpacing(8);
+  }
+  const auto buttons = widget->findChildren<QAbstractButton *>();
+  for (QAbstractButton *b : buttons) {
+    b->setMinimumHeight(28);
+  }
+  const auto groups = widget->findChildren<QGroupBox *>();
+  for (QGroupBox *g : groups) {
+    g->setStyleSheet(
+        "QGroupBox{font-weight:bold;margin-top:10px;border:1px solid #ddd;"
+        "padding-top:10px;}QGroupBox::title{subcontrol-origin:margin;left:8px;"
+        "top:-7px;background:#fafafa;padding:0 3px;}");
+  }
+}
+
+void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
+                                      const QString &buttonStyle) {
+  QGroupBox *sourceGroupBox = new QGroupBox(tr("Source Configuration"));
+  QFormLayout *sourceLayout = new QFormLayout(sourceGroupBox);
+  QHBoxLayout *srcPathLayout = new QHBoxLayout();
+  sourceDirEdit_ = new QLineEdit();
+  sourceDirEdit_->setReadOnly(true);
+  srcPathLayout->addWidget(sourceDirEdit_);
+  sourceDirButton_ = new QPushButton(tr("Browse..."));
+  sourceDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
+  sourceDirButton_->setStyleSheet(buttonStyle);
+  srcPathLayout->addWidget(sourceDirButton_);
+  connect(sourceDirButton_, &QPushButton::clicked, this,
+          &MainWindow::selectSourceDirectory);
+  sourceLayout->addRow(tr("Source Directory:"), srcPathLayout);
+  QLabel *sourceHint = new QLabel(tr("Select the folder to back up"));
+  sourceHint->setStyleSheet("color: gray; font-style: italic;");
+  sourceLayout->addRow(sourceHint);
+
+  watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
+  QHBoxLayout *watchLayout = new QHBoxLayout(watchGroupBox_);
+  watchToggleCheckBox_ = new QCheckBox(tr("Enable monitoring"));
+  watchLayout->addWidget(watchToggleCheckBox_);
+  watchStatusLabel_ = new QLabel(tr("Monitoring off"));
+  watchStatusLabel_->setStyleSheet("color:#2680eb;");
+  watchLayout->addWidget(watchStatusLabel_);
+  watchLayout->addStretch();
+  connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
+          &MainWindow::onWatchToggleChanged);
+  sourceLayout->addRow(watchGroupBox_);
+  mainLayout->addWidget(sourceGroupBox);
+
+  m_localDestinationGroupBox =
+      new QGroupBox(tr("Local Destination Configuration"));
+  QFormLayout *localDestLayout = new QFormLayout(m_localDestinationGroupBox);
+  QHBoxLayout *destPathLayout = new QHBoxLayout();
+  destinationDirEdit_ = new QLineEdit();
+  destinationDirEdit_->setReadOnly(true);
+  destPathLayout->addWidget(destinationDirEdit_);
+  destinationDirButton_ = new QPushButton(tr("Browse..."));
+  destinationDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
+  destinationDirButton_->setStyleSheet(buttonStyle);
+  destPathLayout->addWidget(destinationDirButton_);
+  connect(destinationDirButton_, &QPushButton::clicked, this,
+          &MainWindow::selectDestinationDirectory);
+  localDestLayout->addRow(tr("Destination Directory (Local):"), destPathLayout);
+  QLabel *destHint = new QLabel(
+      tr("Select destination folder (local or remote)"));
+  destHint->setStyleSheet("color: gray; font-style: italic;");
+  localDestLayout->addRow(destHint);
+  mainLayout->addWidget(m_localDestinationGroupBox);
+
+  sftpSettingsGroupBox_ = new QGroupBox(tr("SFTP Configuration"));
+  QFormLayout *sftpFormLayout = new QFormLayout(sftpSettingsGroupBox_);
+  sftpHostLineEdit_ = new QLineEdit();
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Host:")), sftpHostLineEdit_);
+  sftpPortLineEdit_ = new QLineEdit();
+  sftpPortLineEdit_->setText("22");
+  sftpPortLineEdit_->setValidator(new QIntValidator(1, 65535, this));
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Port:")), sftpPortLineEdit_);
+  sftpUsernameLineEdit_ = new QLineEdit();
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Username:")),
+                         sftpUsernameLineEdit_);
+  sftpPasswordLineEdit_ = new QLineEdit();
+  sftpPasswordLineEdit_->setEchoMode(QLineEdit::Password);
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Password:")),
+                         sftpPasswordLineEdit_);
+  sftpSavePasswordCheckBox_ = new QCheckBox(tr("Save password securely"));
+  sftpFormLayout->addRow(sftpSavePasswordCheckBox_);
+  sftpRemotePathLineEdit_ = new QLineEdit();
+  sftpFormLayout->addRow(new QLabel(tr("SFTP Remote Path:")),
+                         sftpRemotePathLineEdit_);
+  sftpConnectToggleButton_ = new QPushButton(tr("Connect"));
+  sftpConnectToggleButton_->setStyleSheet(buttonStyle);
+  sftpFormLayout->addRow(sftpConnectToggleButton_);
+  connect(sftpConnectToggleButton_, &QPushButton::clicked, this,
+          &MainWindow::onSftpConnectToggleClicked);
+  mainLayout->addWidget(sftpSettingsGroupBox_);
+
+  gcsSettingsGroupBox_ =
+      new QGroupBox(tr("Google Cloud Storage Configuration"));
+  QFormLayout *gcsFormLayout = new QFormLayout(gcsSettingsGroupBox_);
+  gcsBucketNameLineEdit_ = new QLineEdit();
+  gcsBucketNameLineEdit_->setToolTip(
+      tr("Name of your GCS bucket (must exist)"));
+  gcsFormLayout->addRow(new QLabel(tr("GCS Bucket Name:")),
+                        gcsBucketNameLineEdit_);
+  gcsAccountIdentifierLineEdit_ = new QLineEdit();
+  gcsAccountIdentifierLineEdit_->setToolTip(
+      tr("Email linked to your Google account"));
+  gcsFormLayout->addRow(new QLabel(tr("GCS Account Identifier:")),
+                        gcsAccountIdentifierLineEdit_);
+  gcsConnectButton_ = new QPushButton(tr("Log in to Google Drive"));
+  gcsConnectButton_->setStyleSheet(buttonStyle);
+  gcsFormLayout->addRow(gcsConnectButton_);
+  connect(gcsConnectButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsConnectButtonClicked);
+  gcsAuthStatusLabel_ = new QLabel(tr("Status: Not Authenticated"));
+  gcsFormLayout->addRow(gcsAuthStatusLabel_);
+  gcsTestConnectionButton_ = new QPushButton(tr("Test Connection"));
+  gcsTestConnectionButton_->setStyleSheet(buttonStyle);
+  gcsFormLayout->addRow(gcsTestConnectionButton_);
+  connect(gcsTestConnectionButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsTestConnectionClicked);
+  gcsConnectToggleButton_ = new QPushButton(tr("Connect"));
+  gcsConnectToggleButton_->setStyleSheet(buttonStyle);
+  gcsFormLayout->addRow(gcsConnectToggleButton_);
+  connect(gcsConnectToggleButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsConnectToggleClicked);
+  mainLayout->addWidget(gcsSettingsGroupBox_);
+
+  applyUnifiedStyle(sourceGroupBox);
+  applyUnifiedStyle(m_localDestinationGroupBox);
+  applyUnifiedStyle(sftpSettingsGroupBox_);
+  applyUnifiedStyle(gcsSettingsGroupBox_);
+}
+
+void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
+                                            const QString &buttonStyle) {
+  QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Controls"));
+  QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
+  scheduleLayout->addWidget(new QLabel(tr("Backup Time:")), 0, 0);
+  backupTimeEdit_ = new QTimeEdit();
+  backupTimeEdit_->setDisplayFormat("HH:mm");
+
+  QHBoxLayout *scheduleRow = new QHBoxLayout();
+  scheduleRow->setSpacing(6);
+  const QStringList dayLabels = {"M", "T", "W", "T", "F", "S", "S"};
+  for (int i = 0; i < 7; ++i) {
+    QToolButton *btn = new QToolButton();
+    btn->setText(dayLabels[i]);
+    btn->setCheckable(true);
+    btn->setFixedSize(26, 26);
+    btn->setStyleSheet(
+        "QToolButton{border-radius:13px;border:1px solid gray;background:#f0f0f0;}"
+        "QToolButton:checked{background:#2680eb;color:white;}");
+    dayButtons_.append(btn);
+    scheduleRow->addWidget(btn);
+  }
+  scheduleRow->addWidget(backupTimeEdit_);
+  addTimeButton_ = new QToolButton();
+  addTimeButton_->setText("+");
+  addTimeButton_->setFixedSize(26, 26);
+  addTimeButton_->setStyleSheet(
+      "QToolButton{border-radius:13px;border:1px solid gray;background:#e0e0e0;}");
+  scheduleRow->addWidget(addTimeButton_);
+  scheduleLayout->addLayout(scheduleRow, 0, 0, 1, 3);
+  connect(addTimeButton_, &QToolButton::clicked, this,
+          &MainWindow::onAddBackupTimeClicked);
+
+  scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 1, 0, 1, 3);
+  timeListWidget_ = new QListWidget();
+  QFrame *timesFrame = new QFrame();
+  timesFrame->setStyleSheet("background:#f0f0f0;border:1px solid #ccc;");
+  QVBoxLayout *timesLayout = new QVBoxLayout(timesFrame);
+  timesLayout->setContentsMargins(0, 0, 0, 0);
+  timesLayout->addWidget(timeListWidget_);
+  scheduleLayout->addWidget(timesFrame, 2, 0, 1, 3);
+
+  removeTimeButton_ = new QPushButton(tr("Remove Selected"));
+  removeTimeButton_->setStyleSheet(buttonStyle);
+  scheduleLayout->addWidget(removeTimeButton_, 3, 0, 1, 3);
+  connect(removeTimeButton_, &QPushButton::clicked, this,
+          &MainWindow::onRemoveBackupTimeClicked);
+
+  runBackupButton_ = new QPushButton(tr("Run Backup Now"));
+  runBackupButton_->setStyleSheet(buttonStyle);
+  connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
+  scheduleLayout->addWidget(runBackupButton_, 4, 0, 1, 3, Qt::AlignCenter);
+
+  mainLayout->addWidget(scheduleGroupBox);
+  applyUnifiedStyle(scheduleGroupBox);
 }

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -2202,6 +2202,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   QHBoxLayout *srcPathLayout = new QHBoxLayout();
   sourceDirEdit_ = new QLineEdit();
   sourceDirEdit_->setReadOnly(true);
+  sourceDirEdit_->setPlaceholderText(tr("Select the folder to back up"));
   srcPathLayout->addWidget(sourceDirEdit_);
   sourceDirButton_ = new QPushButton(tr("Browse..."));
   sourceDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
@@ -2210,9 +2211,6 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   connect(sourceDirButton_, &QPushButton::clicked, this,
           &MainWindow::selectSourceDirectory);
   sourceLayout->addRow(tr("Source Directory:"), srcPathLayout);
-  QLabel *sourceHint = new QLabel(tr("Select the folder to back up"));
-  sourceHint->setStyleSheet("color: gray; font-style: italic;");
-  sourceLayout->addRow(sourceHint);
 
   watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
   QHBoxLayout *watchLayout = new QHBoxLayout(watchGroupBox_);

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -404,8 +404,8 @@ void MainWindow::onAddWatchEntry() {
   watchEntries_.append(entry);
   dirWatcher_->addPath(dir);
 
-  QString display = QString::fromUtf8("\xF0\x9F\x93\x81 ") +
-                    tr("Surveillance : %1 \u2192 %2")
+  QString display = QString::fromUtf8("\xF0\x9F\x91\x81 ") +
+                    tr(" Monitoring | %1 \u2192 %2")
                         .arg(shortenPathForDisplay(dir),
                              currentDestinationForDisplay());
   QListWidgetItem *item = new QListWidgetItem(display);
@@ -417,11 +417,13 @@ void MainWindow::onAddWatchEntry() {
 
   watchStatusLabel_->setText(
       tr("%1 dossier(s) surveill\u00e9(s)").arg(watchEntries_.size()));
+  updateScheduleSummary();
   adjustHeightToScreen();
 }
 
 void MainWindow::onWatchToggleChanged(bool checked) {
   if (checked) {
+    enableWatch();
     onAddWatchEntry();
   } else {
     disableWatch();
@@ -553,8 +555,8 @@ void MainWindow::refreshWatchEntriesDisplay() {
       destDisp = e.destination;
     }
     destDisp = shortenPathForDisplay(destDisp);
-    QString display = QString::fromUtf8("\xF0\x9F\x93\x81 ") +
-                      tr("Surveillance : %1 \u2192 %2")
+    QString display = QString::fromUtf8("\xF0\x9F\x91\x81 ") +
+                      tr(" Monitoring | %1 \u2192 %2")
                           .arg(shortenPathForDisplay(e.source), destDisp);
     QListWidgetItem *item = new QListWidgetItem(display);
     QFont f = item->font();
@@ -572,15 +574,18 @@ void MainWindow::disableWatch() {
   for (const WatchEntry &e : watchEntries_) {
     dirWatcher_->removePath(e.source);
   }
-  watchEntries_.clear();
-  for (int i = timeListWidget_->count() - 1; i >= 0; --i) {
-    QListWidgetItem *item = timeListWidget_->item(i);
-    if (item->data(Qt::UserRole).toString().startsWith("WATCH|")) {
-      delete item;
-    }
-  }
   pendingWatchPaths_.clear();
   watchStatusLabel_->setText(tr("Monitoring off"));
+  updateScheduleSummary();
+}
+
+void MainWindow::enableWatch() {
+  for (const WatchEntry &e : watchEntries_) {
+    if (!dirWatcher_->directories().contains(e.source))
+      dirWatcher_->addPath(e.source);
+  }
+  watchStatusLabel_->setText(
+      tr("%1 dossier(s) surveill\u00e9(s)").arg(watchEntries_.size()));
   updateScheduleSummary();
 }
 
@@ -1447,8 +1452,13 @@ void MainWindow::loadSettings() {
   settings.endArray();
   settings.endGroup();
   refreshWatchEntriesDisplay();
-  if (watchToggleCheckBox_)
+  if (watchToggleCheckBox_) {
+    bool blocked = watchToggleCheckBox_->blockSignals(true);
     watchToggleCheckBox_->setChecked(!watchEntries_.isEmpty());
+    watchToggleCheckBox_->blockSignals(blocked);
+    if (!watchEntries_.isEmpty())
+      enableWatch();
+  }
 
   settings.beginGroup("SFTP");
   sftpHostLineEdit_->setText(settings.value("host", "").toString());

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -47,7 +47,7 @@ MainWindow::MainWindow(QWidget *parent)
       destinationDirEdit_(nullptr), destinationDirButton_(nullptr),
       backupTimeEdit_(nullptr), addTimeButton_(nullptr),
       timeListWidget_(nullptr), removeTimeButton_(nullptr),
-      runBackupButton_(nullptr),
+      runBackupButton_(nullptr), scheduleSummaryLabel_(nullptr),
       logDisplay_(nullptr), scrollArea_(nullptr), backupModeComboBox_(nullptr),
       m_localDestinationGroupBox(nullptr), sftpSettingsGroupBox_(nullptr),
       sftpHostLineEdit_(nullptr), sftpPortLineEdit_(nullptr),
@@ -537,6 +537,7 @@ void MainWindow::updateScheduleFromUI() {
         gcsBucketNameLineEdit_->text(),
         gcsAccountIdentifierLineEdit_->text());
   }
+  updateScheduleSummary();
 }
 
 void MainWindow::refreshWatchEntriesDisplay() {
@@ -564,6 +565,7 @@ void MainWindow::refreshWatchEntriesDisplay() {
   }
   watchStatusLabel_->setText(
       tr("%1 dossier(s) surveill\u00e9(s)").arg(watchEntries_.size()));
+  updateScheduleSummary();
 }
 
 void MainWindow::disableWatch() {
@@ -579,6 +581,7 @@ void MainWindow::disableWatch() {
   }
   pendingWatchPaths_.clear();
   watchStatusLabel_->setText(tr("Monitoring off"));
+  updateScheduleSummary();
 }
 
 
@@ -1332,6 +1335,7 @@ void MainWindow::onTaskChanged() {
   refreshWatchEntriesDisplay();
   onBackupModeChanged(backupModeComboBox_->currentIndex());
   updateLog("Task details updated in UI from Scheduler state.");
+  updateScheduleSummary();
 }
 
 void MainWindow::onBackupModeChanged(int index) {
@@ -2330,7 +2334,7 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
     btn->setFixedSize(26, 26);
     btn->setStyleSheet(
         "QToolButton{border-radius:13px;border:1px solid gray;background:#f0f0f0;}"
-        "QToolButton:checked{background:#2680eb;color:white;}");
+        "QToolButton:checked{background:#dbeafe;border-color:#2680eb;}");
     dayButtons_.append(btn);
     scheduleRow->addWidget(btn);
   }
@@ -2345,26 +2349,60 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   connect(addTimeButton_, &QToolButton::clicked, this,
           &MainWindow::onAddBackupTimeClicked);
 
-  scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 1, 0, 1, 3);
+  scheduleSummaryLabel_ = new QLabel();
+  scheduleSummaryLabel_->setStyleSheet("font-weight:bold");
+  scheduleLayout->addWidget(scheduleSummaryLabel_, 1, 0, 1, 3);
+
+  scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 2, 0, 1, 3);
   timeListWidget_ = new QListWidget();
   QFrame *timesFrame = new QFrame();
   timesFrame->setStyleSheet("background:#f0f0f0;border:1px solid #ccc;");
   QVBoxLayout *timesLayout = new QVBoxLayout(timesFrame);
   timesLayout->setContentsMargins(0, 0, 0, 0);
   timesLayout->addWidget(timeListWidget_);
-  scheduleLayout->addWidget(timesFrame, 2, 0, 1, 3);
+  scheduleLayout->addWidget(timesFrame, 3, 0, 1, 3);
 
   removeTimeButton_ = new QPushButton(tr("Remove Selected"));
   removeTimeButton_->setStyleSheet(buttonStyle);
-  scheduleLayout->addWidget(removeTimeButton_, 3, 0, 1, 3);
-  connect(removeTimeButton_, &QPushButton::clicked, this,
-          &MainWindow::onRemoveBackupTimeClicked);
-
   runBackupButton_ = new QPushButton(tr("Run Backup Now"));
   runBackupButton_->setStyleSheet(buttonStyle);
-  connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
-  scheduleLayout->addWidget(runBackupButton_, 4, 0, 1, 3, Qt::AlignCenter);
+  connect(removeTimeButton_, &QPushButton::clicked, this,
+          &MainWindow::onRemoveBackupTimeClicked);
+  connect(runBackupButton_, &QPushButton::clicked, this,
+          &MainWindow::runBackupNow);
+  QHBoxLayout *buttonsLayout = new QHBoxLayout();
+  buttonsLayout->addWidget(removeTimeButton_);
+  buttonsLayout->addStretch();
+  buttonsLayout->addWidget(runBackupButton_);
+  scheduleLayout->addLayout(buttonsLayout, 4, 0, 1, 3);
 
   mainLayout->addWidget(scheduleGroupBox);
   applyUnifiedStyle(scheduleGroupBox);
+  updateScheduleSummary();
+}
+
+void MainWindow::updateScheduleSummary() {
+  if (!scheduleSummaryLabel_ || !timeListWidget_)
+    return;
+  int count = 0;
+  QTime earliest;
+  bool first = true;
+  for (int i = 0; i < timeListWidget_->count(); ++i) {
+    QString data = timeListWidget_->item(i)->data(Qt::UserRole).toString();
+    if (data.startsWith("WATCH|"))
+      continue;
+    QString timeStr = data.split('|').value(0);
+    QTime t = QTime::fromString(timeStr, "HH:mm");
+    if (t.isValid() && (first || t < earliest)) {
+      earliest = t;
+      first = false;
+    }
+    ++count;
+  }
+  QString nextText = earliest.isValid() ? earliest.toString("HH:mm") : "--:--";
+  scheduleSummaryLabel_->setText(
+      QString::fromUtf8("\xF0\x9F\x93\x85 %1 scheduled backup%2 | \xF0\x9F\x95\x92 Next: %3")
+          .arg(count)
+          .arg(count == 1 ? "" : "s")
+          .arg(nextText));
 }

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -21,6 +21,7 @@
 #include <QToolButton>
 #include <QLabel>
 #include <QIntValidator>
+#include <QSizePolicy>
 #include <QScreen>
 #include <QMessageBox>
 #include <QSettings>
@@ -156,6 +157,8 @@ void MainWindow::setupUI() {
   backupModeComboBox_->addItem(tr("Local Backup"));
   backupModeComboBox_->addItem(tr("SFTP Backup"));
   backupModeComboBox_->addItem(tr("Google Cloud Storage"));
+  backupModeComboBox_->setStyleSheet(
+      "QComboBox, QAbstractItemView { color: black; }");
   modeLayout->addWidget(backupModeComboBox_);
   modeLayout->addStretch();
   mainLayout->addWidget(headerFrame);
@@ -2172,14 +2175,15 @@ void MainWindow::applyUnifiedStyle(QWidget *widget) {
   }
   const auto buttons = widget->findChildren<QAbstractButton *>();
   for (QAbstractButton *b : buttons) {
-    b->setMinimumHeight(28);
+    b->setMinimumHeight(24);
   }
   const auto groups = widget->findChildren<QGroupBox *>();
   for (QGroupBox *g : groups) {
     g->setStyleSheet(
         "QGroupBox{font-weight:bold;margin-top:10px;border:1px solid #ddd;"
-        "padding-top:10px;}QGroupBox::title{subcontrol-origin:margin;left:8px;"
-        "top:-7px;background:#fafafa;padding:0 3px;}");
+        "border-radius:4px;padding-top:15px;background:#fafafa;}"
+        "QGroupBox::title{subcontrol-origin:margin;left:8px;top:-10px;"
+        "background:#fafafa;padding:0 3px;}");
   }
 }
 
@@ -2212,6 +2216,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   watchLayout->addStretch();
   connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
           &MainWindow::onWatchToggleChanged);
+  watchGroupBox_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
   sourceLayout->addRow(watchGroupBox_);
   mainLayout->addWidget(sourceGroupBox);
 
@@ -2304,7 +2309,7 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
                                             const QString &buttonStyle) {
   QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Controls"));
   QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
-  scheduleLayout->addWidget(new QLabel(tr("Backup Time:")), 0, 0);
+  scheduleGroupBox->setStyleSheet("QGroupBox{background:#f5f5f5;}");
   backupTimeEdit_ = new QTimeEdit();
   backupTimeEdit_->setDisplayFormat("HH:mm");
 

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -137,6 +137,7 @@ void MainWindow::setupUI() {
   scrollArea_->setWidget(centralWidget);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
+  mainLayout->setSpacing(12);
 
   const QString buttonStyle =
       QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;}");
@@ -158,7 +159,8 @@ void MainWindow::setupUI() {
   backupModeComboBox_->addItem(tr("SFTP Backup"));
   backupModeComboBox_->addItem(tr("Google Cloud Storage"));
   backupModeComboBox_->setStyleSheet(
-      "QComboBox, QAbstractItemView { color: black; }");
+      "QComboBox { color: black; }"
+      "QComboBox QAbstractItemView { color: black; background: white; }");
   modeLayout->addWidget(backupModeComboBox_);
   modeLayout->addStretch();
   mainLayout->addWidget(headerFrame);
@@ -1396,6 +1398,8 @@ void MainWindow::onBackupModeChanged(int index) {
           "Backup mode changed to: %1. UI adjusted. File viewer visible: %2.")
           .arg(currentModeText)
           .arg(remoteModeSelected ? "Yes" : "No"));
+  if (centralWidget() && centralWidget()->layout())
+    centralWidget()->layout()->invalidate();
   adjustHeightToScreen();
 }
 
@@ -2181,8 +2185,8 @@ void MainWindow::applyUnifiedStyle(QWidget *widget) {
   for (QGroupBox *g : groups) {
     g->setStyleSheet(
         "QGroupBox{font-weight:bold;margin-top:10px;border:1px solid #ddd;"
-        "border-radius:4px;padding-top:15px;background:#fafafa;}"
-        "QGroupBox::title{subcontrol-origin:margin;left:8px;top:-10px;"
+        "border-radius:4px;padding-top:20px;background:#fafafa;}"
+        "QGroupBox::title{subcontrol-origin:margin;left:8px;top:-12px;"
         "background:#fafafa;padding:0 3px;}");
   }
 }
@@ -2208,6 +2212,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
 
   watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
   QHBoxLayout *watchLayout = new QHBoxLayout(watchGroupBox_);
+  watchLayout->setContentsMargins(4, 4, 4, 4);
   watchToggleCheckBox_ = new QCheckBox(tr("Enable monitoring"));
   watchLayout->addWidget(watchToggleCheckBox_);
   watchStatusLabel_ = new QLabel(tr("Monitoring off"));
@@ -2314,7 +2319,9 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   backupTimeEdit_->setDisplayFormat("HH:mm");
 
   QHBoxLayout *scheduleRow = new QHBoxLayout();
+  scheduleRow->setContentsMargins(0, 0, 0, 0);
   scheduleRow->setSpacing(6);
+  scheduleRow->setAlignment(Qt::AlignCenter);
   const QStringList dayLabels = {"M", "T", "W", "T", "F", "S", "S"};
   for (int i = 0; i < 7; ++i) {
     QToolButton *btn = new QToolButton();

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -17,6 +17,7 @@
 #include <QLineEdit>
 #include <QListWidget>
 #include <QPushButton>
+#include <QVBoxLayout>
 #include <QTextEdit>
 #include <QTimeEdit>
 #include <QTimer>
@@ -180,6 +181,11 @@ private:
   QString currentDestinationForDisplay() const;
 
   void adjustHeightToScreen();
+  void createSourceConfigUI(QVBoxLayout *mainLayout,
+                            const QString &buttonStyle);
+  void createSchedulingControlsUI(QVBoxLayout *mainLayout,
+                                  const QString &buttonStyle);
+  void applyUnifiedStyle(QWidget *widget);
 };
 
 #endif // MAINWINDOW_H

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -110,6 +110,7 @@ private:
   QListWidget *timeListWidget_;
   QPushButton *removeTimeButton_;
   QPushButton *runBackupButton_;
+  QLabel *scheduleSummaryLabel_{nullptr};
   QTextEdit *logDisplay_;
 
   QScrollArea *scrollArea_ = nullptr;
@@ -186,6 +187,7 @@ private:
   void createSchedulingControlsUI(QVBoxLayout *mainLayout,
                                   const QString &buttonStyle);
   void applyUnifiedStyle(QWidget *widget);
+  void updateScheduleSummary();
 };
 
 #endif // MAINWINDOW_H

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -97,6 +97,7 @@ private:
   void saveSettings();
   void updateScheduleFromUI();
   void refreshWatchEntriesDisplay();
+  void enableWatch();
   void disableWatch();
 
   // UI Elements

--- a/backy_x/src/targets/LocalTarget.cpp
+++ b/backy_x/src/targets/LocalTarget.cpp
@@ -29,10 +29,12 @@ bool LocalTarget::beginSession() {
 }
 
 bool LocalTarget::sendFile(const std::string& localPath, const FileMetadata& metadata) {
-    // Treat 'localPath' (first param) as the absoluteSourcePath for this function's logic
+    // Treat 'localPath' (first param) as the absolute source path
     const std::filesystem::path absoluteSourceFsPath(localPath);
-    // Use 'metadata.name' as the targetRelativePath
-    const std::filesystem::path targetRelativeFsPath(metadata.name);
+    // If metadata.name is empty, fall back to the source filename
+    const std::filesystem::path targetRelativeFsPath =
+        metadata.name.empty() ? absoluteSourceFsPath.filename()
+                               : std::filesystem::path(metadata.name);
 
     // Construct the full destination path including any subdirectories from targetRelativeFsPath
     const std::filesystem::path destinationFile = std::filesystem::path(currentBasePath_) / targetRelativeFsPath;

--- a/backy_x/src/targets/SftpTarget.cpp
+++ b/backy_x/src/targets/SftpTarget.cpp
@@ -15,6 +15,7 @@
 #include <QDateTime> // For SFTP date parsing
 #include <QLocale>   // For SFTP date parsing
 #include <QStringList> // For new parseSftpDate
+#include <QHostInfo>   // For host name resolution check
 #include "util/CredentialManager.h" // For createPlatformCredentialManager and CredentialManager class
 
 // For libcurl (SFTP operations)
@@ -329,6 +330,14 @@ bool SftpTarget::beginSession() {
     lastError_.clear(); // Clear any errors from previous operations/sessions.
     if (!m_properlyConfigured) {
         lastError_ = "SFTP Target not properly configured.";
+        std::cerr << "SftpTarget::beginSession: " << lastError_ << std::endl;
+        return false;
+    }
+
+    // Basic host resolution check so invalid hosts fail early
+    QHostInfo info = QHostInfo::fromName(QString::fromStdString(m_host));
+    if (info.error() != QHostInfo::NoError || info.addresses().isEmpty()) {
+        lastError_ = "Failed to resolve host: " + m_host;
         std::cerr << "SftpTarget::beginSession: " << lastError_ << std::endl;
         return false;
     }

--- a/backy_x/tests/test_local_target.cpp
+++ b/backy_x/tests/test_local_target.cpp
@@ -68,6 +68,7 @@ TEST_F(LocalTargetTest, CopySingleFileToRoot) {
 
     // Call sendFile with absolute source path and relative target path (just filename for root)
     FileMetadata dummy{};
+    dummy.name = fileName; // destination path relative to target root
     ASSERT_TRUE(target.sendFile(sourceFile.string(), dummy)) << "LocalTarget sendFile failed for " << sourceFile;
     ASSERT_TRUE(target.endSession()) << "LocalTarget endSession failed.";
 
@@ -99,7 +100,8 @@ TEST_F(LocalTargetTest, CopyFileToSubDirectory) {
     ASSERT_TRUE(target.beginSession()) << "LocalTarget beginSession failed.";
     
     // Call sendFile with absolute source path and relative target path including subdirectory
-    FileMetadata dummy_subdir{}; // Use a different name or ensure scope is limited if concerned
+    FileMetadata dummy_subdir{}; // specify target path including subdirectory
+    dummy_subdir.name = relativeTargetPath;
     ASSERT_TRUE(target.sendFile(sourceFile.string(), dummy_subdir)) << "LocalTarget sendFile failed for " << sourceFile << " to " << relativeTargetPath;
     ASSERT_TRUE(target.endSession()) << "LocalTarget endSession failed.";
 


### PR DESCRIPTION
## Summary
- support default filename in `LocalTarget::sendFile`
- validate host resolution in `SftpTarget::beginSession`
- update LocalTarget tests to specify target paths

## Testing
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6841bc9089888321ba65355e4708fc00