### PR TITLE
Refactor main configuration layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore CMake build directory
 backy_x/build/
+build2/
 backy_x/build_new/
 
 # Ignore other common build artifacts and OS-specific files

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -146,9 +146,9 @@ void MainWindow::setupUI() {
     setMaximumHeight(scr->availableGeometry().height());
   }
 
-  QFrame *headerFrame = new QFrame();
-  headerFrame->setStyleSheet("background:#F5F5F5; border:1px solid #dcdcdc;");
-  QHBoxLayout *modeLayout = new QHBoxLayout(headerFrame);
+  QGroupBox *modeGroupBox = new QGroupBox(tr("Backup Mode Selector"));
+  QHBoxLayout *modeLayout = new QHBoxLayout(modeGroupBox);
+  modeGroupBox->setStyleSheet("QGroupBox{background:#F5F5F5;}");
   QLabel *modeIcon = new QLabel();
   modeIcon->setPixmap(style()->standardIcon(QStyle::SP_DriveHDIcon).pixmap(16, 16));
   modeLayout->addWidget(modeIcon);
@@ -163,7 +163,7 @@ void MainWindow::setupUI() {
       "QComboBox QAbstractItemView { color: black; background: white; }");
   modeLayout->addWidget(backupModeComboBox_);
   modeLayout->addStretch();
-  mainLayout->addWidget(headerFrame);
+  mainLayout->addWidget(modeGroupBox);
 
   createSourceConfigUI(mainLayout, buttonStyle);
 
@@ -321,6 +321,7 @@ void MainWindow::onAddBackupTimeClicked() {
   for (QAbstractButton *btn : dayButtons_)
     btn->setChecked(false);
   updateScheduleFromUI();
+  updateActionButtons();
 }
 
 void MainWindow::onRemoveBackupTimeClicked() {
@@ -342,6 +343,7 @@ void MainWindow::onRemoveBackupTimeClicked() {
   watchStatusLabel_->setText(
       tr("%1 dossier(s) surveill\u00e9(s)").arg(watchEntries_.size()));
   updateScheduleFromUI();
+  updateActionButtons();
 }
 
 void MainWindow::onAddWatchEntry() {
@@ -418,6 +420,7 @@ void MainWindow::onAddWatchEntry() {
   watchStatusLabel_->setText(
       tr("%1 dossier(s) surveill\u00e9(s)").arg(watchEntries_.size()));
   updateScheduleSummary();
+  updateActionButtons();
   adjustHeightToScreen();
 }
 
@@ -568,6 +571,7 @@ void MainWindow::refreshWatchEntriesDisplay() {
   watchStatusLabel_->setText(
       tr("%1 dossier(s) surveill\u00e9(s)").arg(watchEntries_.size()));
   updateScheduleSummary();
+  updateActionButtons();
 }
 
 void MainWindow::disableWatch() {
@@ -577,6 +581,7 @@ void MainWindow::disableWatch() {
   pendingWatchPaths_.clear();
   watchStatusLabel_->setText(tr("Monitoring off"));
   updateScheduleSummary();
+  updateActionButtons();
 }
 
 void MainWindow::enableWatch() {
@@ -587,6 +592,7 @@ void MainWindow::enableWatch() {
   watchStatusLabel_->setText(
       tr("%1 dossier(s) surveill\u00e9(s)").arg(watchEntries_.size()));
   updateScheduleSummary();
+  updateActionButtons();
 }
 
 
@@ -2212,7 +2218,6 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   QHBoxLayout *srcPathLayout = new QHBoxLayout();
   sourceDirEdit_ = new QLineEdit();
   sourceDirEdit_->setReadOnly(true);
-  sourceDirEdit_->setPlaceholderText(tr("Select the folder to back up"));
   srcPathLayout->addWidget(sourceDirEdit_);
   sourceDirButton_ = new QPushButton(tr("Browse..."));
   sourceDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
@@ -2222,20 +2227,28 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
           &MainWindow::selectSourceDirectory);
   sourceLayout->addRow(tr("Source Directory:"), srcPathLayout);
 
+  QLabel *srcHint = new QLabel(tr("Select the folder to back up"));
+  srcHint->setStyleSheet("color: gray; font-style: italic;");
+  sourceLayout->addRow(srcHint);
+  mainLayout->addWidget(sourceGroupBox);
+
   watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
   QHBoxLayout *watchLayout = new QHBoxLayout(watchGroupBox_);
   watchLayout->setContentsMargins(4, 4, 4, 4);
   watchToggleCheckBox_ = new QCheckBox(tr("Enable monitoring"));
   watchLayout->addWidget(watchToggleCheckBox_);
-  watchStatusLabel_ = new QLabel(tr("Monitoring off"));
+  watchStatusLabel_ = new QLabel(tr("0 dossier(s) surveill\xC3\xA9(s)"));
   watchStatusLabel_->setStyleSheet("color:#2680eb;");
   watchLayout->addWidget(watchStatusLabel_);
+  watchAddButton_ = new QPushButton(tr("Add Monitored Folder"));
+  watchAddButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
+  watchLayout->addWidget(watchAddButton_);
   watchLayout->addStretch();
   connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
           &MainWindow::onWatchToggleChanged);
+  connect(watchAddButton_, &QPushButton::clicked, this, &MainWindow::onAddWatchEntry);
   watchGroupBox_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-  sourceLayout->addRow(watchGroupBox_);
-  mainLayout->addWidget(sourceGroupBox);
+  mainLayout->addWidget(watchGroupBox_);
 
   m_localDestinationGroupBox =
       new QGroupBox(tr("Local Destination Configuration"));
@@ -2317,6 +2330,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   mainLayout->addWidget(gcsSettingsGroupBox_);
 
   applyUnifiedStyle(sourceGroupBox);
+  applyUnifiedStyle(watchGroupBox_);
   applyUnifiedStyle(m_localDestinationGroupBox);
   applyUnifiedStyle(sftpSettingsGroupBox_);
   applyUnifiedStyle(gcsSettingsGroupBox_);
@@ -2324,7 +2338,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
 
 void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
                                             const QString &buttonStyle) {
-  QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Controls"));
+  QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Monitoring Summary"));
   QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
   scheduleGroupBox->setStyleSheet("QGroupBox{background:#f5f5f5;}");
   backupTimeEdit_ = new QTimeEdit();
@@ -2369,6 +2383,7 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   timesLayout->setContentsMargins(0, 0, 0, 0);
   timesLayout->addWidget(timeListWidget_);
   scheduleLayout->addWidget(timesFrame, 3, 0, 1, 3);
+  connect(timeListWidget_, &QListWidget::itemSelectionChanged, this, &MainWindow::updateActionButtons);
 
   removeTimeButton_ = new QPushButton(tr("Remove Selected"));
   removeTimeButton_->setStyleSheet(buttonStyle);
@@ -2378,15 +2393,19 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
           &MainWindow::onRemoveBackupTimeClicked);
   connect(runBackupButton_, &QPushButton::clicked, this,
           &MainWindow::runBackupNow);
-  QHBoxLayout *buttonsLayout = new QHBoxLayout();
-  buttonsLayout->addWidget(removeTimeButton_);
-  buttonsLayout->addStretch();
-  buttonsLayout->addWidget(runBackupButton_);
-  scheduleLayout->addLayout(buttonsLayout, 4, 0, 1, 3);
 
   mainLayout->addWidget(scheduleGroupBox);
   applyUnifiedStyle(scheduleGroupBox);
   updateScheduleSummary();
+
+  actionsGroupBox_ = new QGroupBox(tr("Actions"));
+  QHBoxLayout *buttonsLayout = new QHBoxLayout(actionsGroupBox_);
+  buttonsLayout->addWidget(removeTimeButton_);
+  buttonsLayout->addStretch();
+  buttonsLayout->addWidget(runBackupButton_);
+  mainLayout->addWidget(actionsGroupBox_);
+  applyUnifiedStyle(actionsGroupBox_);
+  updateActionButtons();
 }
 
 void MainWindow::updateScheduleSummary() {
@@ -2413,4 +2432,15 @@ void MainWindow::updateScheduleSummary() {
           .arg(count)
           .arg(count == 1 ? "" : "s")
           .arg(nextText));
+}
+
+void MainWindow::updateActionButtons() {
+  bool hasSelection = timeListWidget_ && !timeListWidget_->selectedItems().isEmpty();
+  if (removeTimeButton_)
+    removeTimeButton_->setEnabled(hasSelection);
+  if (runBackupButton_) {
+    QString base = QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;}");
+    QString style = hasSelection ? "background:#2680eb;color:white;" : "background:gray;color:white;";
+    runBackupButton_->setStyleSheet(base + style);
+  }
 }

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -6,7 +6,6 @@
 #include "util/CredentialManager.h"
 
 #include <QApplication>
-#include <QGuiApplication>
 #include <QCloseEvent>
 #include <QCoreApplication>
 #include <QDateTime>
@@ -17,17 +16,19 @@
 #include <QFileSystemWatcher>
 #include <QFormLayout>
 #include <QGridLayout>
+#include <QGuiApplication>
 #include <QHBoxLayout>
-#include <QToolButton>
-#include <QLabel>
 #include <QIntValidator>
-#include <QSizePolicy>
-#include <QScreen>
+#include <QLabel>
+#include <QLineEdit>
 #include <QMessageBox>
+#include <QScreen>
 #include <QSettings>
+#include <QSizePolicy>
 #include <QStandardPaths>
 #include <QTime>
 #include <QTimer>
+#include <QToolButton>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <filesystem>
@@ -62,11 +63,12 @@ MainWindow::MainWindow(QWidget *parent)
       // File Viewer UI Elements
       fileViewerGroupBox_(nullptr), fileViewerDockWidget_(nullptr),
       fileTableWidget_(nullptr), refreshButton_(nullptr),
-      downloadButton_(nullptr), deleteButton_(nullptr), currentPathLabel_(nullptr),
+      downloadButton_(nullptr), deleteButton_(nullptr),
+      currentPathLabel_(nullptr),
       currentRemotePath_("/"), // Initialize currentRemotePath_
-      watchGroupBox_(nullptr),
-      watchToggleCheckBox_(nullptr), watchStatusLabel_(nullptr),
-      dirWatcher_(nullptr), watchTriggerTimer_(nullptr),
+      watchGroupBox_(nullptr), watchToggleCheckBox_(nullptr),
+      watchStatusLabel_(nullptr), dirWatcher_(nullptr),
+      watchTriggerTimer_(nullptr),
       // Core components
       scheduler_(nullptr), localTarget_(nullptr), sftpTarget_(nullptr),
       gcsTarget_(nullptr), // Initialize GCS target member
@@ -137,7 +139,7 @@ void MainWindow::setupUI() {
   scrollArea_->setWidget(centralWidget);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
-  mainLayout->setSpacing(15);
+  mainLayout->setSpacing(20);
 
   const QString buttonStyle = QStringLiteral(
       "QPushButton{padding:4px 12px;border-radius:4px;background:#3A3A3A;"
@@ -152,7 +154,8 @@ void MainWindow::setupUI() {
   QHBoxLayout *modeLayout = new QHBoxLayout(modeGroupBox);
   modeGroupBox->setStyleSheet("QGroupBox{background:#F5F5F5;}");
   QLabel *modeIcon = new QLabel();
-  modeIcon->setPixmap(style()->standardIcon(QStyle::SP_DriveHDIcon).pixmap(16, 16));
+  modeIcon->setPixmap(
+      style()->standardIcon(QStyle::SP_DriveHDIcon).pixmap(16, 16));
   modeLayout->addWidget(modeIcon);
   QLabel *modeLabel = new QLabel(tr("<b>Backup Mode</b>"));
   modeLayout->addWidget(modeLabel);
@@ -175,7 +178,6 @@ void MainWindow::setupUI() {
 
   createSchedulingControlsUI(mainLayout, buttonStyle);
 
-
   QToolButton *logToggleButton = new QToolButton();
   logToggleButton->setText(tr("Logs"));
   logToggleButton->setCheckable(true);
@@ -183,14 +185,17 @@ void MainWindow::setupUI() {
   mainLayout->addWidget(logToggleButton);
   logDisplay_ = new QTextEdit();
   logDisplay_->setReadOnly(true);
-  logDisplay_->setStyleSheet("background:#1e1e1e;color:#e8e8e8;font-family:monospace;");
+  logDisplay_->setStyleSheet(
+      "background:#1e1e1e;color:#e8e8e8;font-family:monospace;");
   logDisplay_->setVisible(false);
   logDisplay_->setMaximumHeight(150);
   mainLayout->addWidget(logDisplay_);
-  connect(logToggleButton, &QToolButton::toggled, [this, logToggleButton](bool checked) {
-    logDisplay_->setVisible(checked);
-    logToggleButton->setArrowType(checked ? Qt::DownArrow : Qt::RightArrow);
-  });
+  connect(logToggleButton, &QToolButton::toggled,
+          [this, logToggleButton](bool checked) {
+            logDisplay_->setVisible(checked);
+            logToggleButton->setArrowType(checked ? Qt::DownArrow
+                                                  : Qt::RightArrow);
+          });
   mainLayout->setStretchFactor(logDisplay_, 1);
 
   // File Viewer GroupBox within a DockWidget
@@ -349,12 +354,11 @@ void MainWindow::onRemoveBackupTimeClicked() {
 }
 
 void MainWindow::onAddWatchEntry() {
-  QString dir = sourceDirEdit_->text();
-  if (dir.isEmpty()) {
-    QMessageBox::warning(this, tr("Configuration Error"),
-                         tr("Source path cannot be empty."));
+  QString initial = sourceDirEdit_->text();
+  QString dir = QFileDialog::getExistingDirectory(
+      this, tr("Select Folder to Monitor"), initial);
+  if (dir.isEmpty())
     return;
-  }
   QString modeText = backupModeComboBox_->currentText();
   bool localMode = (modeText == tr("Local Backup"));
   bool sftpMode = (modeText == tr("SFTP Backup"));
@@ -408,10 +412,10 @@ void MainWindow::onAddWatchEntry() {
   watchEntries_.append(entry);
   dirWatcher_->addPath(dir);
 
-  QString display = QString::fromUtf8("\xF0\x9F\x91\x81 ") +
-                    tr(" Monitoring | %1 \u2192 %2")
-                        .arg(shortenPathForDisplay(dir),
-                             currentDestinationForDisplay());
+  QString display =
+      QString::fromUtf8("\xF0\x9F\x91\x81 ") +
+      tr(" Monitoring | %1 \u2192 %2")
+          .arg(shortenPathForDisplay(dir), currentDestinationForDisplay());
   QListWidgetItem *item = new QListWidgetItem(display);
   QFont f = item->font();
   f.setItalic(true);
@@ -427,12 +431,10 @@ void MainWindow::onAddWatchEntry() {
 }
 
 void MainWindow::onWatchToggleChanged(bool checked) {
-  if (checked) {
+  if (checked)
     enableWatch();
-    onAddWatchEntry();
-  } else {
+  else
     disableWatch();
-  }
 }
 
 void MainWindow::onDirectoryChanged(const QString &path) {
@@ -447,8 +449,9 @@ void MainWindow::onWatchTimerTimeout() {
   for (const QString &p : pendingWatchPaths_) {
     for (const WatchEntry &e : watchEntries_) {
       if (e.source == p) {
-        updateLog(tr("Modification détectée dans %1, lancement de la sauvegarde.")
-                      .arg(e.source));
+        updateLog(
+            tr("Modification détectée dans %1, lancement de la sauvegarde.")
+                .arg(e.source));
         if (e.isGcsMode) {
           std::map<std::string, std::string> cfg;
           cfg["gcs_bucket_name"] = e.gcsBucketName.toStdString();
@@ -504,8 +507,8 @@ void MainWindow::updateScheduleFromUI() {
 
   if (sourcePath.isEmpty() || entries.isEmpty()) {
     scheduler_->setDailyBackupTask("", "", {}, false, false, QString(), 0,
-                                  QString(), QString(), false, QString(),
-                                  QString());
+                                   QString(), QString(), false, QString(),
+                                   QString());
     return;
   }
 
@@ -541,8 +544,7 @@ void MainWindow::updateScheduleFromUI() {
     scheduler_->setDailyBackupTask(
         sourcePath, QString("gcs://%1").arg(gcsBucketNameLineEdit_->text()),
         entries, true, false, QString(), 0, QString(), QString(), true,
-        gcsBucketNameLineEdit_->text(),
-        gcsAccountIdentifierLineEdit_->text());
+        gcsBucketNameLineEdit_->text(), gcsAccountIdentifierLineEdit_->text());
   }
   updateScheduleSummary();
 }
@@ -596,7 +598,6 @@ void MainWindow::enableWatch() {
   updateScheduleSummary();
   updateActionButtons();
 }
-
 
 void MainWindow::runBackupNow() {
   QString sourcePath = sourceDirEdit_->text();
@@ -724,8 +725,7 @@ void MainWindow::runBackupNow() {
 }
 
 void MainWindow::onGcsConnectButtonClicked() {
-  updateLog(
-      tr("GCS 'Log in to Google Drive' button clicked (OAuth process)."));
+  updateLog(tr("GCS 'Log in to Google Drive' button clicked (OAuth process)."));
   QString bucketName = gcsBucketNameLineEdit_->text();
   QString accountId = gcsAccountIdentifierLineEdit_->text();
 
@@ -1326,8 +1326,8 @@ void MainWindow::onTaskChanged() {
       QString srcDisp = shortenPathForDisplay(scheduler_->sourcePath());
       QString destDisp;
       if (scheduler_->isSftpMode()) {
-        destDisp = QString("%1:%2")
-                       .arg(scheduler_->sftpHost(), scheduler_->sftpRemotePath());
+        destDisp = QString("%1:%2").arg(scheduler_->sftpHost(),
+                                        scheduler_->sftpRemotePath());
       } else if (scheduler_->isGcsMode()) {
         destDisp = QString("gcs://%1").arg(scheduler_->gcsBucketName());
       } else {
@@ -2173,8 +2173,8 @@ QString MainWindow::shortenPathForDisplay(const QString &path) const {
 QString MainWindow::currentDestinationForDisplay() const {
   QString currentModeText = backupModeComboBox_->currentText();
   if (currentModeText == tr("SFTP Backup")) {
-    return QString("%1:%2")
-        .arg(sftpHostLineEdit_->text(), sftpRemotePathLineEdit_->text());
+    return QString("%1:%2").arg(sftpHostLineEdit_->text(),
+                                sftpRemotePathLineEdit_->text());
   } else if (currentModeText == tr("Google Cloud Storage")) {
     return QString("gcs://%1").arg(gcsBucketNameLineEdit_->text());
   }
@@ -2203,10 +2203,15 @@ void MainWindow::applyUnifiedStyle(QWidget *widget) {
   for (QAbstractButton *b : buttons) {
     b->setMinimumHeight(24);
   }
+  const auto edits = widget->findChildren<QLineEdit *>();
+  for (QLineEdit *e : edits) {
+    e->setStyleSheet("QLineEdit{background:#444;color:#f0f0f0;}"
+                     "QLineEdit::placeholder{color:#bbb;}");
+  }
   const auto groups = widget->findChildren<QGroupBox *>();
   for (QGroupBox *g : groups) {
     g->setStyleSheet(
-        "QGroupBox{font-weight:bold;margin-top:10px;border:1px solid #444;"
+        "QGroupBox{font-weight:bold;margin-top:15px;border:1px solid #444;"
         "border-radius:4px;padding-top:20px;background:#2d2d2d;color:#f0f0f0;}"
         "QGroupBox::title{subcontrol-origin:margin;left:8px;top:-12px;"
         "background:#2d2d2d;padding:0 3px;}");
@@ -2220,6 +2225,8 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   QHBoxLayout *srcPathLayout = new QHBoxLayout();
   sourceDirEdit_ = new QLineEdit();
   sourceDirEdit_->setReadOnly(true);
+  sourceDirEdit_->setMinimumWidth(400);
+  sourceDirEdit_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
   srcPathLayout->addWidget(sourceDirEdit_);
   sourceDirButton_ = new QPushButton(tr("Browse..."));
   sourceDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
@@ -2247,7 +2254,8 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   watchLayout->addStretch();
   connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
           &MainWindow::onWatchToggleChanged);
-  connect(watchAddButton_, &QPushButton::clicked, this, &MainWindow::onAddWatchEntry);
+  connect(watchAddButton_, &QPushButton::clicked, this,
+          &MainWindow::onAddWatchEntry);
   watchGroupBox_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
   mainLayout->addWidget(watchGroupBox_);
 
@@ -2257,6 +2265,9 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   QHBoxLayout *destPathLayout = new QHBoxLayout();
   destinationDirEdit_ = new QLineEdit();
   destinationDirEdit_->setReadOnly(true);
+  destinationDirEdit_->setMinimumWidth(400);
+  destinationDirEdit_->setSizePolicy(QSizePolicy::Expanding,
+                                     QSizePolicy::Preferred);
   destPathLayout->addWidget(destinationDirEdit_);
   destinationDirButton_ = new QPushButton(tr("Browse..."));
   destinationDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
@@ -2265,8 +2276,8 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   connect(destinationDirButton_, &QPushButton::clicked, this,
           &MainWindow::selectDestinationDirectory);
   localDestLayout->addRow(tr("Destination Directory (Local):"), destPathLayout);
-  QLabel *destHint = new QLabel(
-      tr("Select destination folder (local or remote)"));
+  QLabel *destHint =
+      new QLabel(tr("Select destination folder (local or remote)"));
   destHint->setStyleSheet("color: gray; font-style: italic;");
   localDestLayout->addRow(destHint);
   mainLayout->addWidget(m_localDestinationGroupBox);
@@ -2339,7 +2350,8 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
 
 void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
                                             const QString &buttonStyle) {
-  QGroupBox *scheduleGroupBox = new QGroupBox(tr("Scheduling & Monitoring Summary"));
+  QGroupBox *scheduleGroupBox =
+      new QGroupBox(tr("Scheduling & Monitoring Summary"));
   QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
   scheduleGroupBox->setStyleSheet("QGroupBox{background:#f5f5f5;}");
   backupTimeEdit_ = new QTimeEdit();
@@ -2356,7 +2368,8 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
     btn->setCheckable(true);
     btn->setFixedSize(26, 26);
     btn->setStyleSheet(
-        "QToolButton{border-radius:13px;border:1px solid gray;background:#f0f0f0;}"
+        "QToolButton{border-radius:13px;border:1px solid "
+        "gray;background:#f0f0f0;}"
         "QToolButton:checked{background:#dbeafe;border-color:#2680eb;}");
     dayButtons_.append(btn);
     scheduleRow->addWidget(btn);
@@ -2365,8 +2378,8 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   addTimeButton_ = new QToolButton();
   addTimeButton_->setText("+");
   addTimeButton_->setFixedSize(26, 26);
-  addTimeButton_->setStyleSheet(
-      "QToolButton{border-radius:13px;border:1px solid gray;background:#e0e0e0;}");
+  addTimeButton_->setStyleSheet("QToolButton{border-radius:13px;border:1px "
+                                "solid gray;background:#e0e0e0;}");
   scheduleRow->addWidget(addTimeButton_);
   scheduleLayout->addLayout(scheduleRow, 0, 0, 1, 3);
   connect(addTimeButton_, &QToolButton::clicked, this,
@@ -2386,7 +2399,8 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   timeListWidget_->setStyleSheet("background-color:#2E2E2E;color:#F0F0F0;");
   timesLayout->addWidget(timeListWidget_);
   scheduleLayout->addWidget(timesFrame, 3, 0, 1, 3);
-  connect(timeListWidget_, &QListWidget::itemSelectionChanged, this, &MainWindow::updateActionButtons);
+  connect(timeListWidget_, &QListWidget::itemSelectionChanged, this,
+          &MainWindow::updateActionButtons);
 
   removeTimeButton_ = new QPushButton(tr("Remove Selected"));
   removeTimeButton_->setStyleSheet(buttonStyle);
@@ -2431,20 +2445,24 @@ void MainWindow::updateScheduleSummary() {
   }
   QString nextText = earliest.isValid() ? earliest.toString("HH:mm") : "--:--";
   scheduleSummaryLabel_->setText(
-      QString::fromUtf8("\xF0\x9F\x93\x85 %1 scheduled backup%2 | \xF0\x9F\x95\x92 Next: %3")
+      QString::fromUtf8(
+          "\xF0\x9F\x93\x85 %1 scheduled backup%2 | \xF0\x9F\x95\x92 Next: %3")
           .arg(count)
           .arg(count == 1 ? "" : "s")
           .arg(nextText));
 }
 
 void MainWindow::updateActionButtons() {
-  bool hasSelection = timeListWidget_ && !timeListWidget_->selectedItems().isEmpty();
+  bool hasEntries = timeListWidget_ && timeListWidget_->count() > 0;
+  bool hasSelection =
+      timeListWidget_ && !timeListWidget_->selectedItems().isEmpty();
   if (removeTimeButton_)
     removeTimeButton_->setEnabled(hasSelection);
   if (runBackupButton_) {
-    QString base =
-        QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;color:white;}");
-    QString style = hasSelection ? "background:#2680eb;" : "background:#555;";
+    runBackupButton_->setEnabled(hasEntries);
+    QString base = QStringLiteral(
+        "QPushButton{padding:4px 12px;border-radius:4px;color:white;}");
+    QString style = hasEntries ? "background:#2680eb;" : "background:#555;";
     runBackupButton_->setStyleSheet(base + style);
   }
 }

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -141,10 +141,7 @@ void MainWindow::setupUI() {
   QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
   mainLayout->setSpacing(20);
 
-  const QString buttonStyle = QStringLiteral(
-      "QPushButton{padding:4px 12px;border-radius:4px;background:#3A3A3A;"
-      "color:white;}"
-      "QPushButton:disabled{background:#555;color:#bbb;}");
+  const QString buttonStyle = QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;}" "QPushButton:enabled{background:palette(button);color:palette(button-text);}" "QPushButton:disabled{background:palette(mid);color:palette(midlight);}");
   setMinimumSize(800, 600);
   if (QScreen *scr = QApplication::primaryScreen()) {
     setMaximumHeight(scr->availableGeometry().height());
@@ -152,7 +149,6 @@ void MainWindow::setupUI() {
 
   QGroupBox *modeGroupBox = new QGroupBox(tr("Backup Mode Selector"));
   QHBoxLayout *modeLayout = new QHBoxLayout(modeGroupBox);
-  modeGroupBox->setStyleSheet("QGroupBox{background:#F5F5F5;}");
   QLabel *modeIcon = new QLabel();
   modeIcon->setPixmap(
       style()->standardIcon(QStyle::SP_DriveHDIcon).pixmap(16, 16));
@@ -169,6 +165,7 @@ void MainWindow::setupUI() {
   modeLayout->addWidget(backupModeComboBox_);
   modeLayout->addStretch();
   mainLayout->addWidget(modeGroupBox);
+  applyUnifiedStyle(modeGroupBox);
 
   createSourceConfigUI(mainLayout, buttonStyle);
 
@@ -2205,16 +2202,18 @@ void MainWindow::applyUnifiedStyle(QWidget *widget) {
   }
   const auto edits = widget->findChildren<QLineEdit *>();
   for (QLineEdit *e : edits) {
-    e->setStyleSheet("QLineEdit{background:#444;color:#f0f0f0;}"
-                     "QLineEdit::placeholder{color:#bbb;}");
+    e->setStyleSheet(
+        "QLineEdit{background:palette(base);color:palette(text);}"
+        "QLineEdit::placeholder{color:palette(mid);}");
   }
   const auto groups = widget->findChildren<QGroupBox *>();
   for (QGroupBox *g : groups) {
     g->setStyleSheet(
-        "QGroupBox{font-weight:bold;margin-top:15px;border:1px solid #444;"
-        "border-radius:4px;padding-top:20px;background:#2d2d2d;color:#f0f0f0;}"
-        "QGroupBox::title{subcontrol-origin:margin;left:8px;top:-12px;"
-        "background:#2d2d2d;padding:0 3px;}");
+        "QGroupBox{font-weight:bold;margin-top:15px;border:1px solid palette(mid);"
+        "border-radius:4px;padding-top:20px;background:palette(window);"
+        "color:palette(window-text);}"
+        "QGroupBox::title{subcontrol-origin:margin;left:8px;top:-8px;"
+        "background:palette(window);padding:0 3px;}");
   }
 }
 
@@ -2222,6 +2221,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
                                       const QString &buttonStyle) {
   QGroupBox *sourceGroupBox = new QGroupBox(tr("Source Configuration"));
   QFormLayout *sourceLayout = new QFormLayout(sourceGroupBox);
+  sourceLayout->setLabelAlignment(Qt::AlignLeft | Qt::AlignVCenter);
   QHBoxLayout *srcPathLayout = new QHBoxLayout();
   sourceDirEdit_ = new QLineEdit();
   sourceDirEdit_->setReadOnly(true);
@@ -2250,7 +2250,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   watchAddButton_ = new QPushButton(tr("Add Monitored Folder"));
   watchAddButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
   watchAddButton_->setStyleSheet(buttonStyle);
-  watchLayout->addWidget(watchAddButton_);
+  watchLayout->addWidget(watchAddButton_, 0, Qt::AlignVCenter);
   watchLayout->addStretch();
   connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
           &MainWindow::onWatchToggleChanged);
@@ -2262,6 +2262,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   m_localDestinationGroupBox =
       new QGroupBox(tr("Local Destination Configuration"));
   QFormLayout *localDestLayout = new QFormLayout(m_localDestinationGroupBox);
+  localDestLayout->setLabelAlignment(Qt::AlignLeft | Qt::AlignVCenter);
   QHBoxLayout *destPathLayout = new QHBoxLayout();
   destinationDirEdit_ = new QLineEdit();
   destinationDirEdit_->setReadOnly(true);
@@ -2284,6 +2285,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
 
   sftpSettingsGroupBox_ = new QGroupBox(tr("SFTP Configuration"));
   QFormLayout *sftpFormLayout = new QFormLayout(sftpSettingsGroupBox_);
+  sftpFormLayout->setLabelAlignment(Qt::AlignLeft | Qt::AlignVCenter);
   sftpHostLineEdit_ = new QLineEdit();
   sftpFormLayout->addRow(new QLabel(tr("SFTP Host:")), sftpHostLineEdit_);
   sftpPortLineEdit_ = new QLineEdit();
@@ -2312,6 +2314,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   gcsSettingsGroupBox_ =
       new QGroupBox(tr("Google Cloud Storage Configuration"));
   QFormLayout *gcsFormLayout = new QFormLayout(gcsSettingsGroupBox_);
+  gcsFormLayout->setLabelAlignment(Qt::AlignLeft | Qt::AlignVCenter);
   gcsBucketNameLineEdit_ = new QLineEdit();
   gcsBucketNameLineEdit_->setToolTip(
       tr("Name of your GCS bucket (must exist)"));
@@ -2353,7 +2356,7 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   QGroupBox *scheduleGroupBox =
       new QGroupBox(tr("Scheduling & Monitoring Summary"));
   QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
-  scheduleGroupBox->setStyleSheet("QGroupBox{background:#f5f5f5;}");
+  scheduleLayout->setVerticalSpacing(8);
   backupTimeEdit_ = new QTimeEdit();
   backupTimeEdit_->setDisplayFormat("HH:mm");
 
@@ -2393,10 +2396,12 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   timeListWidget_ = new QListWidget();
   QFrame *timesFrame = new QFrame();
   timesFrame->setStyleSheet(
-      "background:#2E2E2E;border:1px solid #444;color:#F0F0F0;");
+      "background:palette(base);border:1px solid palette(mid);"
+      "color:palette(text);");
   QVBoxLayout *timesLayout = new QVBoxLayout(timesFrame);
   timesLayout->setContentsMargins(0, 0, 0, 0);
-  timeListWidget_->setStyleSheet("background-color:#2E2E2E;color:#F0F0F0;");
+  timeListWidget_->setStyleSheet(
+      "background:palette(base);color:palette(text);");
   timesLayout->addWidget(timeListWidget_);
   scheduleLayout->addWidget(timesFrame, 3, 0, 1, 3);
   connect(timeListWidget_, &QListWidget::itemSelectionChanged, this,

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -137,10 +137,12 @@ void MainWindow::setupUI() {
   scrollArea_->setWidget(centralWidget);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
-  mainLayout->setSpacing(12);
+  mainLayout->setSpacing(15);
 
-  const QString buttonStyle =
-      QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;}");
+  const QString buttonStyle = QStringLiteral(
+      "QPushButton{padding:4px 12px;border-radius:4px;background:#3A3A3A;"
+      "color:white;}"
+      "QPushButton:disabled{background:#555;color:#bbb;}");
   setMinimumSize(800, 600);
   if (QScreen *scr = QApplication::primaryScreen()) {
     setMaximumHeight(scr->availableGeometry().height());
@@ -2194,8 +2196,8 @@ void MainWindow::applyUnifiedStyle(QWidget *widget) {
   if (!widget)
     return;
   if (auto layout = widget->layout()) {
-    layout->setContentsMargins(8, 8, 8, 8);
-    layout->setSpacing(8);
+    layout->setContentsMargins(10, 10, 10, 10);
+    layout->setSpacing(10);
   }
   const auto buttons = widget->findChildren<QAbstractButton *>();
   for (QAbstractButton *b : buttons) {
@@ -2204,10 +2206,10 @@ void MainWindow::applyUnifiedStyle(QWidget *widget) {
   const auto groups = widget->findChildren<QGroupBox *>();
   for (QGroupBox *g : groups) {
     g->setStyleSheet(
-        "QGroupBox{font-weight:bold;margin-top:10px;border:1px solid #ddd;"
-        "border-radius:4px;padding-top:20px;background:#fafafa;}"
+        "QGroupBox{font-weight:bold;margin-top:10px;border:1px solid #444;"
+        "border-radius:4px;padding-top:20px;background:#2d2d2d;color:#f0f0f0;}"
         "QGroupBox::title{subcontrol-origin:margin;left:8px;top:-12px;"
-        "background:#fafafa;padding:0 3px;}");
+        "background:#2d2d2d;padding:0 3px;}");
   }
 }
 
@@ -2227,9 +2229,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
           &MainWindow::selectSourceDirectory);
   sourceLayout->addRow(tr("Source Directory:"), srcPathLayout);
 
-  QLabel *srcHint = new QLabel(tr("Select the folder to back up"));
-  srcHint->setStyleSheet("color: gray; font-style: italic;");
-  sourceLayout->addRow(srcHint);
+  sourceDirEdit_->setPlaceholderText(tr("Select the folder to back up"));
   mainLayout->addWidget(sourceGroupBox);
 
   watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
@@ -2242,6 +2242,7 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   watchLayout->addWidget(watchStatusLabel_);
   watchAddButton_ = new QPushButton(tr("Add Monitored Folder"));
   watchAddButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
+  watchAddButton_->setStyleSheet(buttonStyle);
   watchLayout->addWidget(watchAddButton_);
   watchLayout->addStretch();
   connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
@@ -2378,9 +2379,11 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 2, 0, 1, 3);
   timeListWidget_ = new QListWidget();
   QFrame *timesFrame = new QFrame();
-  timesFrame->setStyleSheet("background:#f0f0f0;border:1px solid #ccc;");
+  timesFrame->setStyleSheet(
+      "background:#2E2E2E;border:1px solid #444;color:#F0F0F0;");
   QVBoxLayout *timesLayout = new QVBoxLayout(timesFrame);
   timesLayout->setContentsMargins(0, 0, 0, 0);
+  timeListWidget_->setStyleSheet("background-color:#2E2E2E;color:#F0F0F0;");
   timesLayout->addWidget(timeListWidget_);
   scheduleLayout->addWidget(timesFrame, 3, 0, 1, 3);
   connect(timeListWidget_, &QListWidget::itemSelectionChanged, this, &MainWindow::updateActionButtons);
@@ -2439,8 +2442,9 @@ void MainWindow::updateActionButtons() {
   if (removeTimeButton_)
     removeTimeButton_->setEnabled(hasSelection);
   if (runBackupButton_) {
-    QString base = QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;}");
-    QString style = hasSelection ? "background:#2680eb;color:white;" : "background:gray;color:white;";
+    QString base =
+        QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;color:white;}");
+    QString style = hasSelection ? "background:#2680eb;" : "background:#555;";
     runBackupButton_->setStyleSheet(base + style);
   }
 }

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -113,6 +113,7 @@ private:
   QPushButton *runBackupButton_;
   QLabel *scheduleSummaryLabel_{nullptr};
   QTextEdit *logDisplay_;
+  QGroupBox *actionsGroupBox_ = nullptr;
 
   QScrollArea *scrollArea_ = nullptr;
 
@@ -155,6 +156,7 @@ private:
   QGroupBox *watchGroupBox_ = nullptr;
   QCheckBox *watchToggleCheckBox_ = nullptr;
   QLabel *watchStatusLabel_ = nullptr;
+  QPushButton *watchAddButton_ = nullptr;
 
   QFileSystemWatcher *dirWatcher_ = nullptr;
   QTimer *watchTriggerTimer_ = nullptr;
@@ -189,6 +191,7 @@ private:
                                   const QString &buttonStyle);
   void applyUnifiedStyle(QWidget *widget);
   void updateScheduleSummary();
+  void updateActionButtons();
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## Summary
- restructure backup mode section into its own group box
- separate monitoring configuration into dedicated group
- add actions group containing run/remove buttons
- hint labels and dynamic button state logic

## Testing
- `cmake -S . -B build2`
- `cmake --build build2`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6841f8e5f77c8321ae565f6f4582cb18