### PR TITLE
Add simple light theme stylesheet

### DIFF
--- a/backy_x/CMakeLists.txt
+++ b/backy_x/CMakeLists.txt
@@ -116,6 +116,11 @@ if(WIN32)
     set_target_properties(backy_full_gui PROPERTIES WIN32_EXECUTABLE ON)
 endif()
 
+# Copy stylesheet to build directory and install alongside the executable
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/theme.qss
+               ${CMAKE_CURRENT_BINARY_DIR}/theme.qss COPYONLY)
+install(FILES theme.qss DESTINATION bin)
+
 # --------------------------------------------------------------------
 # ============== tests unitaire GoogleTest ===========================
 enable_testing()

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -146,9 +146,10 @@ void MainWindow::setupUI() {
     setMaximumHeight(scr->availableGeometry().height());
   }
 
-  QFrame *headerFrame = new QFrame();
-  headerFrame->setStyleSheet("background:#F5F5F5; border:1px solid #dcdcdc;");
-  QHBoxLayout *modeLayout = new QHBoxLayout(headerFrame);
+  QWidget *modeWidget = new QWidget();
+  QHBoxLayout *modeLayout = new QHBoxLayout(modeWidget);
+  modeLayout->setContentsMargins(0, 0, 0, 0);
+  modeLayout->setAlignment(Qt::AlignVCenter);
   QLabel *modeIcon = new QLabel();
   modeIcon->setPixmap(style()->standardIcon(QStyle::SP_DriveHDIcon).pixmap(16, 16));
   modeLayout->addWidget(modeIcon);
@@ -158,12 +159,9 @@ void MainWindow::setupUI() {
   backupModeComboBox_->addItem(tr("Local Backup"));
   backupModeComboBox_->addItem(tr("SFTP Backup"));
   backupModeComboBox_->addItem(tr("Google Cloud Storage"));
-  backupModeComboBox_->setStyleSheet(
-      "QComboBox { color: black; }"
-      "QComboBox QAbstractItemView { color: black; background: white; }");
   modeLayout->addWidget(backupModeComboBox_);
   modeLayout->addStretch();
-  mainLayout->addWidget(headerFrame);
+  mainLayout->addWidget(modeWidget);
 
   createSourceConfigUI(mainLayout, buttonStyle);
 
@@ -2221,6 +2219,12 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
           &MainWindow::selectSourceDirectory);
   sourceLayout->addRow(tr("Source Directory:"), srcPathLayout);
 
+  QLabel *sourceHint = new QLabel(
+      tr("Select the folder that will serve as the source for backups."));
+  sourceHint->setWordWrap(true);
+  sourceHint->setStyleSheet("margin-top:8px; color: gray;");
+  sourceLayout->addRow(sourceHint);
+
   watchGroupBox_ = new QGroupBox(tr("Automatic Folder Monitoring"));
   QHBoxLayout *watchLayout = new QHBoxLayout(watchGroupBox_);
   watchLayout->setContentsMargins(4, 4, 4, 4);
@@ -2250,9 +2254,10 @@ void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
   connect(destinationDirButton_, &QPushButton::clicked, this,
           &MainWindow::selectDestinationDirectory);
   localDestLayout->addRow(tr("Destination Directory (Local):"), destPathLayout);
-  QLabel *destHint = new QLabel(
-      tr("Select destination folder (local or remote)"));
-  destHint->setStyleSheet("color: gray; font-style: italic;");
+  QLabel *destHint =
+      new QLabel(tr("Select destination folder (local or remote)"));
+  destHint->setWordWrap(true);
+  destHint->setStyleSheet("margin-top:8px; color: gray; font-style: italic;");
   localDestLayout->addRow(destHint);
   mainLayout->addWidget(m_localDestinationGroupBox);
 
@@ -2336,12 +2341,10 @@ void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
   const QStringList dayLabels = {"M", "T", "W", "T", "F", "S", "S"};
   for (int i = 0; i < 7; ++i) {
     QToolButton *btn = new QToolButton();
+    btn->setObjectName("daySelector");
     btn->setText(dayLabels[i]);
     btn->setCheckable(true);
     btn->setFixedSize(26, 26);
-    btn->setStyleSheet(
-        "QToolButton{border-radius:13px;border:1px solid gray;background:#f0f0f0;}"
-        "QToolButton:checked{background:#dbeafe;border-color:#2680eb;}");
     dayButtons_.append(btn);
     scheduleRow->addWidget(btn);
   }

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -181,7 +181,6 @@ void MainWindow::setupUI() {
   mainLayout->addWidget(logToggleButton);
   logDisplay_ = new QTextEdit();
   logDisplay_->setReadOnly(true);
-  logDisplay_->setStyleSheet("background:#1e1e1e;color:#e8e8e8;font-family:monospace;");
   logDisplay_->setVisible(false);
   logDisplay_->setMaximumHeight(150);
   mainLayout->addWidget(logDisplay_);

--- a/backy_x/src/gui/main_gui.cpp
+++ b/backy_x/src/gui/main_gui.cpp
@@ -1,6 +1,8 @@
 #include "gui/MainWindow.h" // Adjust path if necessary
 #include <QApplication>
 #include <QCoreApplication> // For setting Org/App name
+#include <QFile>
+#include <QString>
 #include <curl/curl.h>      // For libcurl global init/cleanup
 #include <iostream>         // For std::cout
 
@@ -19,6 +21,13 @@ int main(int argc, char *argv[]) {
     // This is important for Scheduler and MainWindow settings.
     QCoreApplication::setOrganizationName("BackyFullOrg"); // Replace with your actual org name
     QCoreApplication::setApplicationName("BackyFull");    // Replace with your actual app name
+
+    // Load global style sheet
+    QFile styleFile(QCoreApplication::applicationDirPath() + "/theme.qss");
+    if (styleFile.open(QFile::ReadOnly | QFile::Text)) {
+        QString style = QString::fromUtf8(styleFile.readAll());
+        app.setStyleSheet(style);
+    }
 
     MainWindow mainWindow;
     mainWindow.show();

--- a/backy_x/theme.qss
+++ b/backy_x/theme.qss
@@ -9,6 +9,7 @@ QWidget {
 QLineEdit, QComboBox, QTextEdit {
     background: #ffffff;
     border: 1px solid #ccc;
+    border-radius: 3px;
     padding: 6px;
 }
 QLineEdit:focus, QComboBox:focus, QTextEdit:focus {
@@ -36,9 +37,19 @@ QPushButton:pressed {
 }
 
 /* Optional day selector buttons */
-QPushButton.daySelector {
+QToolButton#daySelector {
     font-weight: bold;
     color: #007acc;
+    border: 1px solid #ccc;
+    background: #f0f0f0;
+    border-radius: 13px;
+}
+QToolButton#daySelector:hover {
+    background: #e6e6e6;
+}
+QToolButton#daySelector:checked {
+    background: #dbeafe;
+    border-color: #2680eb;
 }
 
 /* Group boxes */
@@ -46,6 +57,7 @@ QGroupBox {
     border: 1px solid #ccc;
     border-radius: 6px;
     margin-top: 10px;
+    margin-bottom: 16px;
     padding: 10px;
 }
 QGroupBox::title {
@@ -53,7 +65,7 @@ QGroupBox::title {
     subcontrol-position: top left;
     padding: 0 3px;
     font-weight: bold;
-    color: #2680eb;
+    color: #3f51b5;
 }
 
 /* Labels and check boxes */

--- a/backy_x/theme.qss
+++ b/backy_x/theme.qss
@@ -1,0 +1,62 @@
+/* Base widget style */
+QWidget {
+    background: #f5f5f5;
+    font-family: sans-serif;
+    font-size: 13px;
+}
+
+/* Line edits and combo boxes */
+QLineEdit, QComboBox, QTextEdit {
+    background: #ffffff;
+    border: 1px solid #ccc;
+    padding: 6px;
+}
+QLineEdit:focus, QComboBox:focus, QTextEdit:focus {
+    border: 1px solid #007acc;
+}
+QComboBox QAbstractItemView {
+    background: #ffffff;
+    selection-background-color: #e6f2ff;
+}
+
+/* Push buttons */
+QPushButton {
+    background: #ffffff;
+    border: 1px solid #ccc;
+    padding: 6px 12px;
+    min-height: 30px;
+    min-width: 80px;
+    border-radius: 4px;
+}
+QPushButton:hover {
+    background: #e6f2ff;
+}
+QPushButton:pressed {
+    background: #d4e8ff;
+}
+
+/* Optional day selector buttons */
+QPushButton.daySelector {
+    font-weight: bold;
+    color: #007acc;
+}
+
+/* Group boxes */
+QGroupBox {
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    margin-top: 10px;
+    padding: 10px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top left;
+    padding: 0 3px;
+    font-weight: bold;
+    color: #2680eb;
+}
+
+/* Labels and check boxes */
+QLabel, QCheckBox {
+    spacing: 4px;
+}


### PR DESCRIPTION
## Summary
- add a `theme.qss` stylesheet describing a light look for widgets
- load the stylesheet on GUI startup
- remove hard coded dark styling from log widget
- copy the style file during build/install

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68427a3f6d2c832183ae585875dba4e6