### PR TITLE
Refactor MainWindow to use .ui file

### DIFF
--- a/backy_x/CMakeLists.txt
+++ b/backy_x/CMakeLists.txt
@@ -106,6 +106,7 @@ target_compile_options(backy_x_cli PRIVATE -Wall -Wextra -pedantic)
 add_executable(backy_full_gui
     src/gui/main_gui.cpp
     src/gui/MainWindow.cpp
+    src/gui/MainWindow.ui
     src/gui/FileViewerWidget.cpp
     src/gui/WatchManager.cpp
 )

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include "util/CredentialManager.h"
 #include "gui/FileViewerWidget.h"
 #include "gui/WatchManager.h"
+#include "ui_MainWindow.h"
 
 #include <QApplication>
 #include <QGuiApplication>
@@ -40,7 +41,7 @@
 #include <QMenuBar>
 
 MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent), sourceDirEdit_(nullptr), sourceDirButton_(nullptr),
+    : QMainWindow(parent), ui(new Ui::MainWindow), sourceDirEdit_(nullptr), sourceDirButton_(nullptr),
       destinationDirEdit_(nullptr), destinationDirButton_(nullptr),
       backupTimeEdit_(nullptr), addTimeButton_(nullptr),
       timeListWidget_(nullptr), removeTimeButton_(nullptr),
@@ -100,6 +101,7 @@ MainWindow::MainWindow(QWidget *parent)
 }
 
 MainWindow::~MainWindow() {
+  delete ui;
   delete localTarget_;
   localTarget_ = nullptr;
   delete sftpTarget_;
@@ -114,80 +116,109 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 }
 
 void MainWindow::setupUI() {
-  setWindowTitle(tr("BackyFull - Backup Configuration"));
+  ui->setupUi(this);
 
-  // Menu bar
-  QMenu *viewMenu = menuBar()->addMenu(tr("&View"));
-
-  scrollArea_ = new QScrollArea(this);
-  setCentralWidget(scrollArea_);
-  scrollArea_->setWidgetResizable(true);
-  QWidget *centralWidget = new QWidget(scrollArea_);
-  scrollArea_->setWidget(centralWidget);
-
-  QVBoxLayout *mainLayout = new QVBoxLayout(centralWidget);
-  mainLayout->setSpacing(12);
+  // Menu
+  QMenu *viewMenu = ui->menuView;
+  if (!viewMenu)
+    viewMenu = menuBar()->addMenu(tr("&View"));
+  if (ui->actionToggleFileViewer)
+    ui->menuView->removeAction(ui->actionToggleFileViewer);
 
   const QString buttonStyle =
       QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;}");
+
+  // Store pointers to widgets from UI
+  scrollArea_ = ui->scrollArea;
+  sourceDirEdit_ = ui->sourceDirEdit;
+  sourceDirButton_ = ui->sourceDirButton;
+  destinationDirEdit_ = ui->destinationDirEdit;
+  destinationDirButton_ = ui->destinationDirButton;
+  backupModeComboBox_ = ui->backupModeComboBox;
+  backupTimeEdit_ = ui->backupTimeEdit;
+  addTimeButton_ = ui->addTimeButton;
+  timeListWidget_ = ui->timeListWidget;
+  removeTimeButton_ = ui->removeTimeButton;
+  runBackupButton_ = ui->runBackupButton;
+  scheduleSummaryLabel_ = ui->scheduleSummaryLabel;
+  logDisplay_ = ui->logDisplay;
+  QToolButton *logToggleButton = ui->logToggleButton;
+  m_localDestinationGroupBox = ui->localDestinationGroupBox;
+  sftpSettingsGroupBox_ = ui->sftpSettingsGroupBox;
+  sftpHostLineEdit_ = ui->sftpHostLineEdit;
+  sftpPortLineEdit_ = ui->sftpPortLineEdit;
+  sftpUsernameLineEdit_ = ui->sftpUsernameLineEdit;
+  sftpPasswordLineEdit_ = ui->sftpPasswordLineEdit;
+  sftpRemotePathLineEdit_ = ui->sftpRemotePathLineEdit;
+  sftpSavePasswordCheckBox_ = ui->sftpSavePasswordCheckBox;
+  sftpConnectToggleButton_ = ui->sftpConnectToggleButton;
+  gcsSettingsGroupBox_ = ui->gcsSettingsGroupBox;
+  gcsBucketNameLineEdit_ = ui->gcsBucketNameLineEdit;
+  gcsAccountIdentifierLineEdit_ = ui->gcsAccountIdentifierLineEdit;
+  gcsConnectButton_ = ui->gcsConnectButton;
+  gcsTestConnectionButton_ = ui->gcsTestConnectionButton;
+  gcsAuthStatusLabel_ = ui->gcsAuthStatusLabel;
+  gcsConnectToggleButton_ = ui->gcsConnectToggleButton;
+  watchToggleCheckBox_ = ui->watchToggleCheckBox;
+  watchStatusLabel_ = ui->watchStatusLabel;
+  fileViewerDockWidget_ = ui->fileViewerDockWidget;
+
+  // Collect day buttons
+  dayButtons_.clear();
+  dayButtons_ << ui->dayButton1 << ui->dayButton2 << ui->dayButton3
+              << ui->dayButton4 << ui->dayButton5 << ui->dayButton6
+              << ui->dayButton7;
+
+  applyUnifiedStyle(ui->sourceGroupBox);
+  applyUnifiedStyle(ui->localDestinationGroupBox);
+  applyUnifiedStyle(ui->sftpSettingsGroupBox);
+  applyUnifiedStyle(ui->gcsSettingsGroupBox);
+  applyUnifiedStyle(ui->scheduleGroupBox);
+
   setMinimumSize(800, 600);
   if (QScreen *scr = QApplication::primaryScreen()) {
     setMaximumHeight(scr->availableGeometry().height());
   }
 
-  QWidget *modeWidget = new QWidget();
-  QHBoxLayout *modeLayout = new QHBoxLayout(modeWidget);
-  modeLayout->setContentsMargins(0, 0, 0, 0);
-  modeLayout->setAlignment(Qt::AlignVCenter);
-  QLabel *modeIcon = new QLabel();
-  modeIcon->setPixmap(style()->standardIcon(QStyle::SP_DriveHDIcon).pixmap(16, 16));
-  modeLayout->addWidget(modeIcon);
-  QLabel *modeLabel = new QLabel(tr("<b>Backup Mode</b>"));
-  modeLayout->addWidget(modeLabel);
-  backupModeComboBox_ = new QComboBox();
+  ui->modeIcon->setPixmap(style()->standardIcon(QStyle::SP_DriveHDIcon).pixmap(16, 16));
   backupModeComboBox_->addItem(tr("Local Backup"));
   backupModeComboBox_->addItem(tr("SFTP Backup"));
   backupModeComboBox_->addItem(tr("Google Cloud Storage"));
-  modeLayout->addWidget(backupModeComboBox_);
-  modeLayout->addStretch();
-  mainLayout->addWidget(modeWidget);
 
-  createSourceConfigUI(mainLayout, buttonStyle);
-
-  connect(backupModeComboBox_,
-          QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-          &MainWindow::onBackupModeChanged);
-
-  createSchedulingControlsUI(mainLayout, buttonStyle);
-
-
-  QToolButton *logToggleButton = new QToolButton();
-  logToggleButton->setText(tr("Logs"));
-  logToggleButton->setCheckable(true);
-  logToggleButton->setArrowType(Qt::RightArrow);
-  mainLayout->addWidget(logToggleButton);
-  logDisplay_ = new QTextEdit();
-  logDisplay_->setReadOnly(true);
-  logDisplay_->setVisible(false);
-  logDisplay_->setMaximumHeight(150);
-  mainLayout->addWidget(logDisplay_);
-  connect(logToggleButton, &QToolButton::toggled, [this, logToggleButton](bool checked) {
-    logDisplay_->setVisible(checked);
-    logToggleButton->setArrowType(checked ? Qt::DownArrow : Qt::RightArrow);
-  });
-  mainLayout->setStretchFactor(logDisplay_, 1);
-
-  // File Viewer GroupBox within a DockWidget
+  // Setup File Viewer dock widget
   fileViewerWidget_ = new FileViewerWidget();
-
-  fileViewerDockWidget_ = new QDockWidget(tr("Remote File Browser"), this);
   fileViewerDockWidget_->setWidget(fileViewerWidget_);
   fileViewerDockWidget_->setMinimumSize(250, 300);
   addDockWidget(Qt::RightDockWidgetArea, fileViewerDockWidget_);
   fileViewerDockWidget_->hide();
   viewMenu->addAction(fileViewerDockWidget_->toggleViewAction());
 
-  // Relay log messages from the viewer
+  // Connections
+  connect(sourceDirButton_, &QPushButton::clicked, this,
+          &MainWindow::selectSourceDirectory);
+  connect(destinationDirButton_, &QPushButton::clicked, this,
+          &MainWindow::selectDestinationDirectory);
+  connect(backupModeComboBox_, QOverload<int>::of(&QComboBox::currentIndexChanged),
+          this, &MainWindow::onBackupModeChanged);
+  connect(addTimeButton_, &QToolButton::clicked, this,
+          &MainWindow::onAddBackupTimeClicked);
+  connect(removeTimeButton_, &QPushButton::clicked, this,
+          &MainWindow::onRemoveBackupTimeClicked);
+  connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
+  connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
+          &MainWindow::onWatchToggleChanged);
+  connect(gcsConnectButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsConnectButtonClicked);
+  connect(gcsTestConnectionButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsTestConnectionClicked);
+  connect(gcsConnectToggleButton_, &QPushButton::clicked, this,
+          &MainWindow::onGcsConnectToggleClicked);
+  connect(sftpConnectToggleButton_, &QPushButton::clicked, this,
+          &MainWindow::onSftpConnectToggleClicked);
+  connect(logToggleButton, &QToolButton::toggled, this, [this, logToggleButton](bool checked) {
+    logDisplay_->setVisible(checked);
+    logToggleButton->setArrowType(checked ? Qt::DownArrow : Qt::RightArrow);
+  });
   connect(fileViewerWidget_, &FileViewerWidget::logMessage, this,
           &MainWindow::updateLog);
 
@@ -1573,194 +1604,6 @@ void MainWindow::applyUnifiedStyle(QWidget *widget) {
   }
 }
 
-void MainWindow::createSourceConfigUI(QVBoxLayout *mainLayout,
-                                      const QString &buttonStyle) {
-  QGroupBox *sourceGroupBox = new QGroupBox(tr("Source Configuration"));
-  QFormLayout *sourceLayout = new QFormLayout(sourceGroupBox);
-  QHBoxLayout *srcPathLayout = new QHBoxLayout();
-  sourceDirEdit_ = new QLineEdit();
-  sourceDirEdit_->setReadOnly(true);
-  sourceDirEdit_->setPlaceholderText(tr("Select the folder to back up"));
-  srcPathLayout->addWidget(sourceDirEdit_);
-  sourceDirButton_ = new QPushButton(tr("Browse..."));
-  sourceDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
-  sourceDirButton_->setStyleSheet(buttonStyle);
-  srcPathLayout->addWidget(sourceDirButton_);
-  connect(sourceDirButton_, &QPushButton::clicked, this,
-          &MainWindow::selectSourceDirectory);
-  sourceLayout->addRow(tr("Source Directory:"), srcPathLayout);
-
-  QLabel *sourceHint = new QLabel(
-      tr("Select the folder that will serve as the source for backups."));
-  sourceHint->setWordWrap(true);
-  sourceHint->setStyleSheet("margin-top:8px; color: gray;");
-  sourceLayout->addRow(sourceHint);
-
-  mainLayout->addWidget(sourceGroupBox);
-
-  m_localDestinationGroupBox =
-      new QGroupBox(tr("Local Destination Configuration"));
-  QFormLayout *localDestLayout = new QFormLayout(m_localDestinationGroupBox);
-  QHBoxLayout *destPathLayout = new QHBoxLayout();
-  destinationDirEdit_ = new QLineEdit();
-  destinationDirEdit_->setReadOnly(true);
-  destPathLayout->addWidget(destinationDirEdit_);
-  destinationDirButton_ = new QPushButton(tr("Browse..."));
-  destinationDirButton_->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
-  destinationDirButton_->setStyleSheet(buttonStyle);
-  destPathLayout->addWidget(destinationDirButton_);
-  connect(destinationDirButton_, &QPushButton::clicked, this,
-          &MainWindow::selectDestinationDirectory);
-  localDestLayout->addRow(tr("Destination Directory (Local):"), destPathLayout);
-  QLabel *destHint =
-      new QLabel(tr("Select destination folder (local or remote)"));
-  destHint->setWordWrap(true);
-  destHint->setStyleSheet("margin-top:8px; color: gray; font-style: italic;");
-  localDestLayout->addRow(destHint);
-  mainLayout->addWidget(m_localDestinationGroupBox);
-
-  sftpSettingsGroupBox_ = new QGroupBox(tr("SFTP Configuration"));
-  QFormLayout *sftpFormLayout = new QFormLayout(sftpSettingsGroupBox_);
-  sftpHostLineEdit_ = new QLineEdit();
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Host:")), sftpHostLineEdit_);
-  sftpPortLineEdit_ = new QLineEdit();
-  sftpPortLineEdit_->setText("22");
-  sftpPortLineEdit_->setValidator(new QIntValidator(1, 65535, this));
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Port:")), sftpPortLineEdit_);
-  sftpUsernameLineEdit_ = new QLineEdit();
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Username:")),
-                         sftpUsernameLineEdit_);
-  sftpPasswordLineEdit_ = new QLineEdit();
-  sftpPasswordLineEdit_->setEchoMode(QLineEdit::Password);
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Password:")),
-                         sftpPasswordLineEdit_);
-  sftpSavePasswordCheckBox_ = new QCheckBox(tr("Save password securely"));
-  sftpFormLayout->addRow(sftpSavePasswordCheckBox_);
-  sftpRemotePathLineEdit_ = new QLineEdit();
-  sftpFormLayout->addRow(new QLabel(tr("SFTP Remote Path:")),
-                         sftpRemotePathLineEdit_);
-  sftpConnectToggleButton_ = new QPushButton(tr("Connect"));
-  sftpConnectToggleButton_->setStyleSheet(buttonStyle);
-  sftpFormLayout->addRow(sftpConnectToggleButton_);
-  connect(sftpConnectToggleButton_, &QPushButton::clicked, this,
-          &MainWindow::onSftpConnectToggleClicked);
-  mainLayout->addWidget(sftpSettingsGroupBox_);
-
-  gcsSettingsGroupBox_ =
-      new QGroupBox(tr("Google Cloud Storage Configuration"));
-  QFormLayout *gcsFormLayout = new QFormLayout(gcsSettingsGroupBox_);
-  gcsBucketNameLineEdit_ = new QLineEdit();
-  gcsBucketNameLineEdit_->setToolTip(
-      tr("Name of your GCS bucket (must exist)"));
-  gcsFormLayout->addRow(new QLabel(tr("GCS Bucket Name:")),
-                        gcsBucketNameLineEdit_);
-  gcsAccountIdentifierLineEdit_ = new QLineEdit();
-  gcsAccountIdentifierLineEdit_->setToolTip(
-      tr("Email linked to your Google account"));
-  gcsFormLayout->addRow(new QLabel(tr("GCS Account Identifier:")),
-                        gcsAccountIdentifierLineEdit_);
-  gcsConnectButton_ = new QPushButton(tr("Log in to Google Drive"));
-  gcsConnectButton_->setStyleSheet(buttonStyle);
-  gcsFormLayout->addRow(gcsConnectButton_);
-  connect(gcsConnectButton_, &QPushButton::clicked, this,
-          &MainWindow::onGcsConnectButtonClicked);
-  gcsAuthStatusLabel_ = new QLabel(tr("Status: Not Authenticated"));
-  gcsFormLayout->addRow(gcsAuthStatusLabel_);
-  gcsTestConnectionButton_ = new QPushButton(tr("Test Connection"));
-  gcsTestConnectionButton_->setStyleSheet(buttonStyle);
-  gcsFormLayout->addRow(gcsTestConnectionButton_);
-  connect(gcsTestConnectionButton_, &QPushButton::clicked, this,
-          &MainWindow::onGcsTestConnectionClicked);
-  gcsConnectToggleButton_ = new QPushButton(tr("Connect"));
-  gcsConnectToggleButton_->setStyleSheet(buttonStyle);
-  gcsFormLayout->addRow(gcsConnectToggleButton_);
-  connect(gcsConnectToggleButton_, &QPushButton::clicked, this,
-          &MainWindow::onGcsConnectToggleClicked);
-  mainLayout->addWidget(gcsSettingsGroupBox_);
-
-  applyUnifiedStyle(sourceGroupBox);
-  applyUnifiedStyle(m_localDestinationGroupBox);
-  applyUnifiedStyle(sftpSettingsGroupBox_);
-  applyUnifiedStyle(gcsSettingsGroupBox_);
-}
-
-void MainWindow::createSchedulingControlsUI(QVBoxLayout *mainLayout,
-                                            const QString &buttonStyle) {
-  QGroupBox *scheduleGroupBox = new QGroupBox(tr("Backup Settings"));
-  QGridLayout *scheduleLayout = new QGridLayout(scheduleGroupBox);
-  scheduleGroupBox->setStyleSheet("QGroupBox{background:#f5f5f5;}");
-  backupTimeEdit_ = new QTimeEdit();
-  backupTimeEdit_->setDisplayFormat("HH:mm");
-
-  QHBoxLayout *scheduleRow = new QHBoxLayout();
-  scheduleRow->setContentsMargins(0, 0, 0, 0);
-  scheduleRow->setSpacing(6);
-  scheduleRow->setAlignment(Qt::AlignCenter);
-  const QStringList dayLabels = {"M", "T", "W", "T", "F", "S", "S"};
-  for (int i = 0; i < 7; ++i) {
-    QToolButton *btn = new QToolButton();
-    btn->setObjectName("daySelector");
-    btn->setText(dayLabels[i]);
-    btn->setCheckable(true);
-    btn->setFixedSize(26, 26);
-    dayButtons_.append(btn);
-    scheduleRow->addWidget(btn);
-  }
-  scheduleRow->addWidget(backupTimeEdit_);
-  addTimeButton_ = new QToolButton();
-  addTimeButton_->setText("+");
-  addTimeButton_->setFixedSize(26, 26);
-  addTimeButton_->setStyleSheet(
-      "QToolButton{border-radius:13px;border:1px solid gray;background:#e0e0e0;}");
-  scheduleRow->addWidget(addTimeButton_);
-  scheduleLayout->addLayout(scheduleRow, 0, 0, 1, 3);
-  connect(addTimeButton_, &QToolButton::clicked, this,
-          &MainWindow::onAddBackupTimeClicked);
-
-  scheduleSummaryLabel_ = new QLabel();
-  scheduleSummaryLabel_->setStyleSheet("font-weight:bold");
-  scheduleLayout->addWidget(scheduleSummaryLabel_, 1, 0, 1, 3);
-
-  scheduleLayout->addWidget(new QLabel(tr("Scheduled Times:")), 2, 0, 1, 3);
-  timeListWidget_ = new QListWidget();
-  QFrame *timesFrame = new QFrame();
-  timesFrame->setStyleSheet("background:#f0f0f0;border:1px solid #ccc;");
-  QVBoxLayout *timesLayout = new QVBoxLayout(timesFrame);
-  timesLayout->setContentsMargins(0, 0, 0, 0);
-  timesLayout->addWidget(timeListWidget_);
-  scheduleLayout->addWidget(timesFrame, 3, 0, 1, 3);
-
-  QHBoxLayout *watchLayout = new QHBoxLayout();
-  watchLayout->setContentsMargins(0, 8, 0, 0);
-  watchLayout->setAlignment(Qt::AlignLeft);
-  watchToggleCheckBox_ = new QCheckBox(tr("Enable monitoring"));
-  watchLayout->addWidget(watchToggleCheckBox_);
-  watchStatusLabel_ = new QLabel(tr("Monitoring off"));
-  watchStatusLabel_->setStyleSheet("color:#2680eb;");
-  watchLayout->addWidget(watchStatusLabel_);
-  watchLayout->addStretch();
-  connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
-          &MainWindow::onWatchToggleChanged);
-  scheduleLayout->addLayout(watchLayout, 4, 0, 1, 3);
-
-  removeTimeButton_ = new QPushButton(tr("Remove Selected"));
-  removeTimeButton_->setStyleSheet(buttonStyle);
-  runBackupButton_ = new QPushButton(tr("Run Backup Now"));
-  runBackupButton_->setStyleSheet(buttonStyle);
-  connect(removeTimeButton_, &QPushButton::clicked, this,
-          &MainWindow::onRemoveBackupTimeClicked);
-  connect(runBackupButton_, &QPushButton::clicked, this,
-          &MainWindow::runBackupNow);
-  QHBoxLayout *buttonsLayout = new QHBoxLayout();
-  buttonsLayout->addWidget(removeTimeButton_);
-  buttonsLayout->addStretch();
-  buttonsLayout->addWidget(runBackupButton_);
-  scheduleLayout->addLayout(buttonsLayout, 5, 0, 1, 3);
-
-  mainLayout->addWidget(scheduleGroupBox);
-  applyUnifiedStyle(scheduleGroupBox);
-  updateScheduleSummary();
-}
 
 void MainWindow::updateScheduleSummary() {
   if (!scheduleSummaryLabel_ || !timeListWidget_)

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -122,8 +122,8 @@ void MainWindow::setupUI() {
   QMenu *viewMenu = ui->menuView;
   if (!viewMenu)
     viewMenu = menuBar()->addMenu(tr("&View"));
-  if (ui->actionToggleFileViewer)
-    ui->menuView->removeAction(ui->actionToggleFileViewer);
+  if (ui->actionToggleFileViewer && viewMenu)
+    viewMenu->removeAction(ui->actionToggleFileViewer);
 
   const QString buttonStyle =
       QStringLiteral("QPushButton{padding:4px 12px;border-radius:4px;}");

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -36,6 +36,10 @@ class GcsTarget; // Forward declare GcsTarget
 class FileViewerWidget;
 class WatchManager;
 
+namespace Ui {
+class MainWindow;
+}
+
 class MainWindow : public QMainWindow {
   Q_OBJECT
 
@@ -69,6 +73,7 @@ private slots:
   void handleWatchTriggered(const WatchEntry &entry);
 
 private:
+  Ui::MainWindow *ui{nullptr};
   void setupUI();
   void loadSettings();
   void saveSettings();
@@ -148,10 +153,6 @@ private:
   QString currentDestinationForDisplay() const;
 
   void adjustHeightToScreen();
-  void createSourceConfigUI(QVBoxLayout *mainLayout,
-                            const QString &buttonStyle);
-  void createSchedulingControlsUI(QVBoxLayout *mainLayout,
-                                  const QString &buttonStyle);
   void applyUnifiedStyle(QWidget *widget);
   void updateScheduleSummary();
 };

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -1,0 +1,597 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="windowTitle">
+   <string>BackyFull - Backup Configuration</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout_main" stretch="">
+    <property name="spacing">
+     <number>12</number>
+    </property>
+    <item>
+     <widget class="QScrollArea" name="scrollArea">
+      <property name="widgetResizable">
+       <bool>true</bool>
+      </property>
+      <widget class="QWidget" name="scrollAreaWidgetContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>100</width>
+         <height>30</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="scrollAreaLayout" stretch="">
+        <property name="spacing">
+         <number>12</number>
+        </property>
+        <!-- Backup mode row -->
+        <item>
+         <widget class="QWidget" name="modeWidget">
+          <layout class="QHBoxLayout" name="modeLayout">
+           <property name="contentsMargins">
+            <left>0</left>
+            <top>0</top>
+            <right>0</right>
+            <bottom>0</bottom>
+           </property>
+           <item>
+            <widget class="QLabel" name="modeIcon"/>
+           </item>
+           <item>
+            <widget class="QLabel" name="modeLabel">
+             <property name="text">
+              <string>&lt;b&gt;Backup Mode&lt;/b&gt;</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="backupModeComboBox"/>
+           </item>
+           <item>
+            <spacer name="modeSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Expanding</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <!-- Source configuration group -->
+        <item>
+         <widget class="QGroupBox" name="sourceGroupBox">
+          <property name="title">
+           <string>Source Configuration</string>
+          </property>
+          <layout class="QFormLayout" name="sourceLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelSourceDir">
+             <property name="text">
+              <string>Source Directory:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <layout class="QHBoxLayout" name="sourcePathLayout">
+             <item>
+              <widget class="QLineEdit" name="sourceDirEdit">
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+               <property name="placeholderText">
+                <string>Select the folder to back up</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="sourceDirButton">
+               <property name="text">
+                <string>Browse...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QLabel" name="sourceHint">
+             <property name="text">
+              <string>Select the folder that will serve as the source for backups.</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <!-- Local destination group -->
+        <item>
+         <widget class="QGroupBox" name="localDestinationGroupBox">
+          <property name="title">
+           <string>Local Destination Configuration</string>
+          </property>
+          <layout class="QFormLayout" name="localDestLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelDestDir">
+             <property name="text">
+              <string>Destination Directory (Local):</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <layout class="QHBoxLayout" name="destPathLayout">
+             <item>
+              <widget class="QLineEdit" name="destinationDirEdit">
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="destinationDirButton">
+               <property name="text">
+                <string>Browse...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QLabel" name="destHint">
+             <property name="text">
+              <string>Select destination folder (local or remote)</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <!-- SFTP group -->
+        <item>
+         <widget class="QGroupBox" name="sftpSettingsGroupBox">
+          <property name="title">
+           <string>SFTP Configuration</string>
+          </property>
+          <layout class="QFormLayout" name="sftpFormLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelSftpHost">
+             <property name="text">
+              <string>SFTP Host:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="sftpHostLineEdit"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelSftpPort">
+             <property name="text">
+              <string>SFTP Port:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="sftpPortLineEdit">
+             <property name="text">
+              <string>22</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="labelSftpUser">
+             <property name="text">
+              <string>SFTP Username:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLineEdit" name="sftpUsernameLineEdit"/>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="labelSftpPass">
+             <property name="text">
+              <string>SFTP Password:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLineEdit" name="sftpPasswordLineEdit">
+             <property name="echoMode">
+              <enum>QLineEdit::Password</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0" colspan="2">
+            <widget class="QCheckBox" name="sftpSavePasswordCheckBox">
+             <property name="text">
+              <string>Save password securely</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="labelSftpRemote">
+             <property name="text">
+              <string>SFTP Remote Path:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QLineEdit" name="sftpRemotePathLineEdit"/>
+           </item>
+           <item row="6" column="0" colspan="2" alignment="Qt::AlignLeft">
+            <widget class="QPushButton" name="sftpConnectToggleButton">
+             <property name="text">
+              <string>Connect</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <!-- GCS group -->
+        <item>
+         <widget class="QGroupBox" name="gcsSettingsGroupBox">
+          <property name="title">
+           <string>Google Cloud Storage Configuration</string>
+          </property>
+          <layout class="QFormLayout" name="gcsFormLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelGcsBucket">
+             <property name="text">
+              <string>GCS Bucket Name:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="gcsBucketNameLineEdit"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelGcsAccount">
+             <property name="text">
+              <string>GCS Account Identifier:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="gcsAccountIdentifierLineEdit"/>
+           </item>
+           <item row="2" column="0" colspan="2" alignment="Qt::AlignLeft">
+            <widget class="QPushButton" name="gcsConnectButton">
+             <property name="text">
+              <string>Log in to Google Drive</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0" colspan="2">
+            <widget class="QLabel" name="gcsAuthStatusLabel">
+             <property name="text">
+              <string>Status: Not Authenticated</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0" colspan="2" alignment="Qt::AlignLeft">
+            <widget class="QPushButton" name="gcsTestConnectionButton">
+             <property name="text">
+              <string>Test Connection</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0" colspan="2" alignment="Qt::AlignLeft">
+            <widget class="QPushButton" name="gcsConnectToggleButton">
+             <property name="text">
+              <string>Connect</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <!-- Schedule group -->
+        <item>
+         <widget class="QGroupBox" name="scheduleGroupBox">
+          <property name="title">
+           <string>Backup Settings</string>
+          </property>
+          <layout class="QGridLayout" name="scheduleLayout">
+           <!-- Row 0: day buttons, time and add -->
+           <item row="0" column="0" colspan="3">
+            <layout class="QHBoxLayout" name="scheduleRow">
+             <item>
+              <widget class="QToolButton" name="dayButton1">
+               <property name="text">
+                <string>M</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="fixedSize">
+                <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="dayButton2">
+               <property name="text">
+                <string>T</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="fixedSize">
+                <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="dayButton3">
+               <property name="text">
+                <string>W</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="fixedSize">
+                <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="dayButton4">
+               <property name="text">
+                <string>T</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="fixedSize">
+                <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="dayButton5">
+               <property name="text">
+                <string>F</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="fixedSize">
+                <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="dayButton6">
+               <property name="text">
+                <string>S</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="fixedSize">
+                <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="dayButton7">
+               <property name="text">
+                <string>S</string>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+               <property name="fixedSize">
+                <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QTimeEdit" name="backupTimeEdit">
+               <property name="displayFormat">
+                <string>HH:mm</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="addTimeButton">
+               <property name="text">
+                <string>+</string>
+               </property>
+               <property name="fixedSize">
+                <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="1" column="0" colspan="3">
+            <widget class="QLabel" name="scheduleSummaryLabel"/>
+           </item>
+           <item row="2" column="0" colspan="3">
+            <widget class="QLabel" name="labelScheduledTimes">
+             <property name="text">
+              <string>Scheduled Times:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0" colspan="3">
+            <widget class="QFrame" name="timesFrame">
+             <layout class="QVBoxLayout" name="timesLayout">
+              <item>
+               <widget class="QListWidget" name="timeListWidget"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="4" column="0" colspan="3">
+            <layout class="QHBoxLayout" name="watchLayout">
+             <item>
+              <widget class="QCheckBox" name="watchToggleCheckBox">
+               <property name="text">
+                <string>Enable monitoring</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="watchStatusLabel">
+               <property name="text">
+                <string>Monitoring off</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="watchSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item row="5" column="0" colspan="3">
+            <layout class="QHBoxLayout" name="buttonsLayout">
+             <item>
+              <widget class="QPushButton" name="removeTimeButton">
+               <property name="text">
+                <string>Remove Selected</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="buttonsSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QPushButton" name="runBackupButton">
+               <property name="text">
+                <string>Run Backup Now</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <!-- Log toggle and display -->
+        <item>
+         <layout class="QVBoxLayout" name="logLayout">
+          <item>
+           <widget class="QToolButton" name="logToggleButton">
+            <property name="text">
+             <string>Logs</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="arrowType">
+             <enum>Qt::RightArrow</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QTextEdit" name="logDisplay">
+            <property name="visible">
+             <bool>false</bool>
+            </property>
+            <property name="maximumHeight">
+             <number>150</number>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QDockWidget" name="fileViewerDockWidget">
+   <property name="windowTitle">
+    <string>Remote File Browser</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
+   <widget class="QWidget" name="dockWidgetContents">
+    <layout class="QVBoxLayout" name="dockLayout">
+     <item>
+      <widget class="QWidget" name="fileViewerWidget"/>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <action name="actionToggleFileViewer">
+   <property name="text">
+    <string>Remote File Browser</string>
+   </property>
+  </action>
+  <menu name="menuView">
+   <property name="title">
+    <string>&amp;View</string>
+   </property>
+   <addaction name="actionToggleFileViewer"/>
+  </menu>
+  <menubar name="menubar">
+   <addaction name="menuView"/>
+  </menubar>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -639,13 +639,13 @@
     <string>Remote File Browser</string>
    </property>
   </action>
-  <widget class="QMenu" name="menuView">
-   <property name="title">
-    <string>&amp;View</string>
-   </property>
-   <addaction name="actionToggleFileViewer"/>
-  </widget>
   <widget class="QMenuBar" name="menubar">
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="actionToggleFileViewer"/>
+   </widget>
    <addaction name="menuView"/>
   </widget>
 </widget>

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -623,6 +623,9 @@
    <property name="visible">
     <bool>false</bool>
    </property>
+   <attribute name="dockWidgetArea">
+    <enum>Qt::RightDockWidgetArea</enum>
+   </attribute>
    <widget class="QWidget" name="dockWidgetContents">
     <layout class="QVBoxLayout" name="dockLayout">
      <item>

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -6,7 +6,7 @@
    <string>BackyFull - Backup Configuration</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout_main" stretch="">
+   <layout class="QVBoxLayout" name="verticalLayout_main">
     <property name="spacing">
      <number>12</number>
     </property>
@@ -24,7 +24,7 @@
          <height>30</height>
         </rect>
        </property>
-       <layout class="QVBoxLayout" name="scrollAreaLayout" stretch="">
+       <layout class="QVBoxLayout" name="scrollAreaLayout">
         <property name="spacing">
          <number>12</number>
         </property>
@@ -32,11 +32,17 @@
         <item>
          <widget class="QWidget" name="modeWidget">
           <layout class="QHBoxLayout" name="modeLayout">
-           <property name="contentsMargins">
-            <left>0</left>
-            <top>0</top>
-            <right>0</right>
-            <bottom>0</bottom>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
            </property>
            <item>
             <widget class="QLabel" name="modeIcon"/>
@@ -321,12 +327,18 @@
                <property name="checkable">
                 <bool>true</bool>
                </property>
-               <property name="fixedSize">
-                <size>
+               <property name="minimumSize">
+ <size>
                  <width>26</width>
                  <height>26</height>
                 </size>
-               </property>
+</property>
+<property name="maximumSize">
+ <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+</property>
               </widget>
              </item>
              <item>
@@ -337,12 +349,18 @@
                <property name="checkable">
                 <bool>true</bool>
                </property>
-               <property name="fixedSize">
-                <size>
+               <property name="minimumSize">
+ <size>
                  <width>26</width>
                  <height>26</height>
                 </size>
-               </property>
+</property>
+<property name="maximumSize">
+ <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+</property>
               </widget>
              </item>
              <item>
@@ -353,12 +371,18 @@
                <property name="checkable">
                 <bool>true</bool>
                </property>
-               <property name="fixedSize">
-                <size>
+               <property name="minimumSize">
+ <size>
                  <width>26</width>
                  <height>26</height>
                 </size>
-               </property>
+</property>
+<property name="maximumSize">
+ <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+</property>
               </widget>
              </item>
              <item>
@@ -369,12 +393,18 @@
                <property name="checkable">
                 <bool>true</bool>
                </property>
-               <property name="fixedSize">
-                <size>
+               <property name="minimumSize">
+ <size>
                  <width>26</width>
                  <height>26</height>
                 </size>
-               </property>
+</property>
+<property name="maximumSize">
+ <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+</property>
               </widget>
              </item>
              <item>
@@ -385,12 +415,18 @@
                <property name="checkable">
                 <bool>true</bool>
                </property>
-               <property name="fixedSize">
-                <size>
+               <property name="minimumSize">
+ <size>
                  <width>26</width>
                  <height>26</height>
                 </size>
-               </property>
+</property>
+<property name="maximumSize">
+ <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+</property>
               </widget>
              </item>
              <item>
@@ -401,12 +437,18 @@
                <property name="checkable">
                 <bool>true</bool>
                </property>
-               <property name="fixedSize">
-                <size>
+               <property name="minimumSize">
+ <size>
                  <width>26</width>
                  <height>26</height>
                 </size>
-               </property>
+</property>
+<property name="maximumSize">
+ <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+</property>
               </widget>
              </item>
              <item>
@@ -417,12 +459,18 @@
                <property name="checkable">
                 <bool>true</bool>
                </property>
-               <property name="fixedSize">
-                <size>
+               <property name="minimumSize">
+ <size>
                  <width>26</width>
                  <height>26</height>
                 </size>
-               </property>
+</property>
+<property name="maximumSize">
+ <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+</property>
               </widget>
              </item>
              <item>
@@ -437,12 +485,18 @@
                <property name="text">
                 <string>+</string>
                </property>
-               <property name="fixedSize">
-                <size>
+               <property name="minimumSize">
+ <size>
                  <width>26</width>
                  <height>26</height>
                 </size>
-               </property>
+</property>
+<property name="maximumSize">
+ <size>
+                 <width>26</width>
+                 <height>26</height>
+                </size>
+</property>
               </widget>
              </item>
             </layout>
@@ -582,16 +636,16 @@
     <string>Remote File Browser</string>
    </property>
   </action>
-  <menu name="menuView">
+  <widget class="QMenu" name="menuView">
    <property name="title">
     <string>&amp;View</string>
    </property>
    <addaction name="actionToggleFileViewer"/>
-  </menu>
-  <menubar name="menubar">
+  </widget>
+  <widget class="QMenuBar" name="menubar">
    <addaction name="menuView"/>
-  </menubar>
- </widget>
+  </widget>
+</widget>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
## Summary
- build `MainWindow.ui` via Qt Designer structure
- hook up generated widgets through `Ui::MainWindow`
- remove manual widget creation
- add ui file to the build system

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_68431c513fa08321804106a1875e0e3a