### PR TITLE
Patch A: toolbar and mode combo items

### DIFF
--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -30,6 +30,7 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QStandardPaths>
+#include <QSplitter>
 #include <QTime>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -121,6 +122,9 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 void MainWindow::setupUI() {
   ui->setupUi(this);
 
+  if (auto spl = findChild<QSplitter*>("centralwidget"))
+    spl->setSizes({200, width() - 200});
+
   // Menu
   QMenu *viewMenu = ui->menuView;
   if (!viewMenu)
@@ -206,6 +210,7 @@ void MainWindow::setupUI() {
   connect(removeTimeButton_, &QPushButton::clicked, this,
           &MainWindow::onRemoveBackupTimeClicked);
   connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
+  connect(ui->actionRunBackup, &QAction::triggered, this, &MainWindow::runBackupNow);
   connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
           &MainWindow::onWatchToggleChanged);
   connect(gcsConnectButton_, &QPushButton::clicked, this,

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -103,7 +103,23 @@
             </widget>
            </item>
            <item>
-            <widget class="QComboBox" name="backupModeComboBox"/>
+            <widget class="QComboBox" name="backupModeComboBox">
+             <item>
+              <property name="text">
+               <string>Local Backup</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>SFTP Backup</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Google Cloud Storage</string>
+              </property>
+             </item>
+            </widget>
            </item>
            <item>
             <spacer name="modeSpacer">
@@ -668,6 +684,14 @@
     <string>Remote File Browser</string>
    </property>
   </action>
+  <action name="actionRunBackup">
+   <property name="text">
+    <string>Run Backup Now</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+R</string>
+   </property>
+  </action>
   <widget class="QMenuBar" name="menubar">
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -676,6 +700,12 @@
     <addaction name="actionToggleFileViewer"/>
    </widget>
   <addaction name="menuView"/>
+ </widget>
+ <widget class="QToolBar" name="mainToolBar">
+  <property name="windowTitle">
+   <string>Tools</string>
+  </property>
+  <addaction name="actionRunBackup"/>
  </widget>
   <widget class="QStatusBar" name="statusBar"/>
 </widget>


### PR DESCRIPTION
## Summary
- add items to `backupModeComboBox` in UI
- add `actionRunBackup` and toolbar with shortcut
- hook toolbar action into `runBackupNow`
- ensure splitter sizes are set if present
- include `QSplitter` header

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68435e220b38832196d56fcc202484ce