### PR TITLE
Remove binary icons; add runtime status dot

### DIFF
--- a/backy_x/include/util/IconUtils.h
+++ b/backy_x/include/util/IconUtils.h
@@ -1,0 +1,20 @@
+#ifndef ICONUTILS_H
+#define ICONUTILS_H
+
+#include <QPixmap>
+#include <QPainter>
+#include <QColor>
+
+inline QPixmap makeStatusDot(const QColor &color, int size = 12)
+{
+    QPixmap pm(size, size);
+    pm.fill(Qt::transparent);
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setBrush(color);
+    p.setPen(Qt::NoPen);
+    p.drawEllipse(0, 0, size - 1, size - 1);
+    return pm;
+}
+
+#endif // ICONUTILS_H

--- a/backy_x/resources/icons.qrc
+++ b/backy_x/resources/icons.qrc
@@ -1,0 +1,4 @@
+<RCC>
+    <qresource prefix="/icons">
+    </qresource>
+</RCC>

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -27,6 +27,8 @@
 #include <QIntValidator>
 #include <QSizePolicy>
 #include <QScreen>
+#include <QPixmap>
+#include "util/IconUtils.h"
 #include <QMessageBox>
 #include <QSettings>
 #include <QStandardPaths>
@@ -63,7 +65,8 @@ MainWindow::MainWindow(QWidget *parent)
       gcsAuthStatusLabel_(nullptr), gcsConnectToggleButton_(nullptr),
       // File Viewer UI Elements
       fileViewerDockWidget_(nullptr), fileViewerWidget_(nullptr),
-      watchToggleCheckBox_(nullptr), watchStatusLabel_(nullptr),
+      cbWatch_(nullptr), lblWatchStatus_(nullptr), sbWatchInterval_(nullptr),
+      lblLastEvent_(nullptr),
       watchManager_(nullptr),
       // Core components
       scheduler_(nullptr), localTarget_(nullptr), sftpTarget_(nullptr),
@@ -166,8 +169,10 @@ void MainWindow::setupUI() {
   gcsTestConnectionButton_ = ui->gcsTestConnectionButton;
   gcsAuthStatusLabel_ = ui->gcsAuthStatusLabel;
   gcsConnectToggleButton_ = ui->gcsConnectToggleButton;
-  watchToggleCheckBox_ = ui->watchToggleCheckBox;
-  watchStatusLabel_ = ui->watchStatusLabel;
+  cbWatch_ = ui->cbWatch;
+  lblWatchStatus_ = ui->lblWatchStatus;
+  sbWatchInterval_ = ui->sbWatchInterval;
+  lblLastEvent_ = ui->lblLastEvent;
   fileViewerDockWidget_ = ui->fileViewerDockWidget;
   backupModeComboBox_ = ui->backupModeComboBox;
   backupModeStackedWidget_ = ui->backupModeStackedWidget;
@@ -182,7 +187,7 @@ void MainWindow::setupUI() {
   applyUnifiedStyle(ui->localDestinationGroupBox);
   applyUnifiedStyle(ui->sftpSettingsGroupBox);
   applyUnifiedStyle(ui->gcsSettingsGroupBox);
-  applyUnifiedStyle(ui->scheduleGroupBox);
+  applyUnifiedStyle(ui->gbSchedule);
 
   setMinimumSize(800, 600);
   if (QScreen *scr = QApplication::primaryScreen()) {
@@ -211,8 +216,9 @@ void MainWindow::setupUI() {
           &MainWindow::onRemoveBackupTimeClicked);
   connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
   connect(ui->actionRunBackup, &QAction::triggered, this, &MainWindow::runBackupNow);
-  connect(watchToggleCheckBox_, &QCheckBox::toggled, this,
-          &MainWindow::onWatchToggleChanged);
+  connect(cbWatch_, &QCheckBox::toggled, this, &MainWindow::onWatchToggled);
+  connect(sbWatchInterval_, QOverload<int>::of(&QSpinBox::valueChanged), this,
+          [this](int v) { watchManager_->setInterval(v); });
   connect(gcsConnectButton_, &QPushButton::clicked, this,
           &MainWindow::onGcsConnectButtonClicked);
   connect(gcsTestConnectionButton_, &QPushButton::clicked, this,
@@ -313,8 +319,8 @@ void MainWindow::onRemoveBackupTimeClicked() {
     }
     delete item;
   }
-  watchStatusLabel_->setText(
-      tr("%1 dossier(s) surveill\u00e9(s)").arg(watchManager_->entries().size()));
+  lblWatchStatus_->setText("");
+  updateWatchStatusIcon();
   updateScheduleFromUI();
 }
 
@@ -387,14 +393,17 @@ void MainWindow::onAddWatchEntry() {
   item->setData(Qt::UserRole, QStringLiteral("WATCH|") + dir);
   timeListWidget_->addItem(item);
 
-  watchStatusLabel_->setText(
-      tr("%1 dossier(s) surveill\u00e9(s)").arg(watchManager_->entries().size()));
+  lblWatchStatus_->setText("");
+  updateWatchStatusIcon();
   updateScheduleSummary();
   adjustHeightToScreen();
 }
 
 void MainWindow::handleWatchTriggered(const WatchEntry &e) {
   updateLog(tr("Modification d\u00e9tect\u00e9e dans %1, lancement de la sauvegarde.").arg(e.source));
+  if (lblLastEvent_)
+    lblLastEvent_->setText(tr("Last event: %1").arg(QDateTime::currentDateTime().toString("dd/MM/yyyy HH:mm:ss")));
+  updateWatchStatusIcon();
   if (e.isGcsMode) {
     std::map<std::string, std::string> cfg;
     cfg["gcs_bucket_name"] = e.gcsBucketName.toStdString();
@@ -419,7 +428,7 @@ void MainWindow::handleWatchTriggered(const WatchEntry &e) {
   }
 }
 
-void MainWindow::onWatchToggleChanged(bool checked) {
+void MainWindow::onWatchToggled(bool checked) {
   if (checked) {
     watchManager_->enable();
     refreshWatchEntriesDisplay();
@@ -433,9 +442,13 @@ void MainWindow::onWatchToggleChanged(bool checked) {
         delete timeListWidget_->takeItem(i);
       }
     }
-    watchStatusLabel_->setText(tr("Monitoring off"));
+    lblWatchStatus_->setText("");
+    updateWatchStatusIcon();
     updateScheduleSummary();
   }
+  sbWatchInterval_->setEnabled(checked);
+  if (checked)
+    watchManager_->setInterval(sbWatchInterval_->value());
 }
 
 
@@ -538,12 +551,7 @@ void MainWindow::refreshWatchEntriesDisplay() {
     item->setData(Qt::UserRole, QStringLiteral("WATCH|") + e.source);
     timeListWidget_->addItem(item);
   }
-  if (watchManager_->entries().isEmpty())
-    watchStatusLabel_->setText(tr("Monitoring off"));
-  else
-    watchStatusLabel_->setText(
-        tr("%1 dossier(s) surveill\u00e9(s)")
-            .arg(watchManager_->entries().size()));
+  updateWatchStatusIcon();
   updateScheduleSummary();
 }
 
@@ -1362,10 +1370,10 @@ void MainWindow::loadSettings() {
   settings.endArray();
   settings.endGroup();
   refreshWatchEntriesDisplay();
-  if (watchToggleCheckBox_) {
-    bool blocked = watchToggleCheckBox_->blockSignals(true);
-    watchToggleCheckBox_->setChecked(!watchManager_->entries().isEmpty());
-    watchToggleCheckBox_->blockSignals(blocked);
+  if (cbWatch_) {
+    bool blocked = cbWatch_->blockSignals(true);
+    cbWatch_->setChecked(!watchManager_->entries().isEmpty());
+    cbWatch_->blockSignals(blocked);
     if (!watchManager_->entries().isEmpty())
       watchManager_->enable();
   }
@@ -1602,6 +1610,15 @@ void MainWindow::adjustHeightToScreen() {
   adjustSize();
   if (height() > avail)
     resize(width(), avail);
+}
+
+void MainWindow::updateWatchStatusIcon() {
+  if (!lblWatchStatus_ || !watchManager_)
+    return;
+  QColor col = watchManager_->hasError() ? Qt::yellow
+               : watchManager_->isEnabled() ? Qt::green
+               : Qt::red;
+  lblWatchStatus_->setPixmap(makeStatusDot(col));
 }
 
 void MainWindow::applyUnifiedStyle(QWidget *widget) {

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -17,6 +17,7 @@
 #include <QLabel> // Added for gcsAuthStatusLabel_
 #include <QLineEdit>
 #include <QListWidget>
+#include <QSpinBox>
 #include <QPushButton>
 #include <QVBoxLayout>
 #include <QTextEdit>
@@ -71,7 +72,8 @@ private slots:
 
   // Auto watch slots
   void onAddWatchEntry();
-  void onWatchToggleChanged(bool checked);
+  void onWatchToggled(bool checked);
+  void updateWatchStatusIcon();
   void handleWatchTriggered(const WatchEntry &entry);
 
 private:
@@ -132,8 +134,10 @@ private:
   QString currentRemotePath_ = "/";
 
   // Auto Watch UI
-  QCheckBox *watchToggleCheckBox_ = nullptr;
-  QLabel *watchStatusLabel_ = nullptr;
+  QCheckBox *cbWatch_ = nullptr;
+  QLabel *lblWatchStatus_ = nullptr;
+  QSpinBox *sbWatchInterval_ = nullptr;
+  QLabel *lblLastEvent_ = nullptr;
 
   WatchManager *watchManager_ = nullptr;
 

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -343,9 +343,9 @@
     </item>
         <!-- Schedule group -->
         <item>
-         <widget class="QGroupBox" name="scheduleGroupBox">
+         <widget class="QGroupBox" name="gbSchedule">
           <property name="title">
-           <string>Backup Settings</string>
+           <string>Backup Schedule</string>
           </property>
           <layout class="QGridLayout" name="scheduleLayout">
            <!-- Row 0: day buttons, time and add -->
@@ -552,34 +552,6 @@
              </layout>
             </widget>
            </item>
-           <item row="4" column="0" colspan="3">
-            <layout class="QHBoxLayout" name="watchLayout">
-             <item>
-              <widget class="QCheckBox" name="watchToggleCheckBox">
-               <property name="text">
-                <string>Enable monitoring</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="watchStatusLabel">
-               <property name="text">
-                <string>Monitoring off</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="watchSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Expanding</enum>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
            <item row="5" column="0" colspan="3">
             <layout class="QHBoxLayout" name="buttonsLayout">
              <item>
@@ -621,6 +593,79 @@
             </property>
            </widget>
           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gbWatch">
+          <property name="title">
+           <string>Real-Time Folder Watch</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_watch">
+           <item>
+            <layout class="QHBoxLayout" name="hlWatch">
+             <item>
+              <widget class="QCheckBox" name="cbWatch">
+               <property name="text">
+                <string>Activate watch on source folder</string>
+               </property>
+               <property name="toolTip">
+                <string>Active un balayage du dossier source toutes les N secondes ; une sauvegarde démarre automatiquement dès qu'un fichier change.</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="lblWatchStatus">
+               <property name="minimumSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QFormLayout" name="formLayoutWatch">
+             <item row="0" column="0">
+              <widget class="QLabel" name="labelWatchInterval">
+               <property name="text">
+                <string>Interval (s)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="sbWatchInterval">
+               <property name="minimum">
+                <number>5</number>
+               </property>
+               <property name="maximum">
+                <number>3600</number>
+               </property>
+               <property name="value">
+                <number>15</number>
+               </property>
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QLabel" name="lblLastEvent">
+             <property name="text">
+              <string>Last event: --/--/---- --:--:--</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>

--- a/backy_x/src/gui/WatchManager.cpp
+++ b/backy_x/src/gui/WatchManager.cpp
@@ -2,17 +2,22 @@
 
 WatchManager::WatchManager(QObject *parent)
     : QObject(parent), watcher_(new QFileSystemWatcher(this)),
-      timer_(new QTimer(this)), enabled_(false) {
+      timer_(new QTimer(this)), enabled_(false), error_(false) {
     timer_->setSingleShot(true);
     connect(watcher_, &QFileSystemWatcher::directoryChanged, this,
             &WatchManager::onDirectoryChanged);
     connect(timer_, &QTimer::timeout, this, &WatchManager::onTimeout);
 }
 
+void WatchManager::setInterval(int seconds) {
+    intervalMs_ = qMax(1, seconds) * 1000;
+}
+
 void WatchManager::addEntry(const WatchEntry &entry) {
     entries_.append(entry);
     if (enabled_) {
-        watcher_->addPath(entry.source);
+        if (!watcher_->addPath(entry.source))
+            error_ = true;
     }
 }
 
@@ -40,9 +45,11 @@ void WatchManager::enable() {
     if (enabled_)
         return;
     enabled_ = true;
+    error_ = false;
     for (const WatchEntry &e : entries_) {
         if (!watcher_->directories().contains(e.source)) {
-            watcher_->addPath(e.source);
+            if (!watcher_->addPath(e.source))
+                error_ = true;
         }
     }
 }
@@ -58,7 +65,7 @@ void WatchManager::disable() {
 void WatchManager::onDirectoryChanged(const QString &path) {
     pending_.insert(path);
     if (!timer_->isActive())
-        timer_->start(3000);
+        timer_->start(intervalMs_);
 }
 
 void WatchManager::onTimeout() {

--- a/backy_x/src/gui/WatchManager.h
+++ b/backy_x/src/gui/WatchManager.h
@@ -27,6 +27,10 @@ class WatchManager : public QObject
 public:
     explicit WatchManager(QObject *parent = nullptr);
 
+    void setInterval(int seconds);
+    int interval() const { return intervalMs_ / 1000; }
+    bool hasError() const { return error_; }
+
     void addEntry(const WatchEntry &entry);
     void removeEntry(const QString &path);
     const QList<WatchEntry> &entries() const { return entries_; }
@@ -48,6 +52,8 @@ private:
     QList<WatchEntry> entries_;
     QSet<QString> pending_;
     bool enabled_;
+    int intervalMs_ = 3000;
+    bool error_ = false;
 };
 
 #endif // WATCHMANAGER_H


### PR DESCRIPTION
## Summary
- remove PNG icons from repo and build
- add `IconUtils::makeStatusDot` for drawing colored dots
- compute watch status color dynamically in `MainWindow`
- track watch errors in `WatchManager`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6843b7707de883218dd98c187ef7110f