### PR TITLE
UI: add JobsModel with schedule/watch table

### DIFF
--- a/backy_x/CMakeLists.txt
+++ b/backy_x/CMakeLists.txt
@@ -38,7 +38,9 @@ set(PROJECT_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 # ============== bibliothèques internes ==============================
 add_library(backy_x_core STATIC
     src/core/Scheduler.cpp
+    src/core/Job.cpp
     ${PROJECT_INCLUDE}/core/Scheduler.h
+    ${PROJECT_INCLUDE}/core/Job.h
 )
 target_include_directories(backy_x_core PUBLIC ${PROJECT_INCLUDE})
 target_link_libraries(backy_x_core PUBLIC Qt6::Core)

--- a/backy_x/include/core/Job.h
+++ b/backy_x/include/core/Job.h
@@ -1,0 +1,43 @@
+#ifndef JOB_H
+#define JOB_H
+
+#include <QAbstractTableModel>
+#include <QBitArray>
+#include <QDateTime>
+#include <QList>
+
+enum class JobType { Scheduled, Watch };
+
+struct Job {
+    JobType type{JobType::Scheduled};
+    QBitArray daysMask;   // Monday=0 .. Sunday=6
+    QTime time;
+    int interval{0};      // seconds for watch
+    QDateTime next;
+    bool enabled{true};
+};
+
+class JobsModel : public QAbstractTableModel {
+    Q_OBJECT
+public:
+    explicit JobsModel(QObject *parent = nullptr);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QVariant headerData(int section, Qt::Orientation orientation,
+                        int role) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+    void addJob(const Job &job);
+    void removeRows(const QList<int> &rows);
+
+    Job &jobRef(int row) { return jobs_[row]; }
+    const QList<Job> &jobs() const { return jobs_; }
+    void setJobNext(int row, const QDateTime &dt);
+
+private:
+    QList<Job> jobs_;
+};
+
+#endif // JOB_H

--- a/backy_x/include/core/Job.h
+++ b/backy_x/include/core/Job.h
@@ -30,7 +30,7 @@ public:
     Qt::ItemFlags flags(const QModelIndex &index) const override;
 
     void addJob(const Job &job);
-    void removeRows(const QList<int> &rows);
+    void removeJobRows(const QList<int> &rows);
 
     Job &jobRef(int row) { return jobs_[row]; }
     const QList<Job> &jobs() const { return jobs_; }

--- a/backy_x/include/core/Scheduler.h
+++ b/backy_x/include/core/Scheduler.h
@@ -9,6 +9,7 @@
 #include <QTime>
 #include <QTimer>
 #include <Qt>
+#include "core/Job.h"
 
 struct ScheduleEntry {
   QTime time;
@@ -71,6 +72,9 @@ public:
   QString gcsBucketName() const;
   QString gcsObjectPrefix() const;
   QString gcsAccountIdentifier() const;
+
+  // Compute and update next run datetime for jobs in model
+  void computeNextRuns(JobsModel *model) const;
 
 signals:
   // Emitted when a scheduled backup is due

--- a/backy_x/src/core/Job.cpp
+++ b/backy_x/src/core/Job.cpp
@@ -63,7 +63,7 @@ void JobsModel::addJob(const Job &job) {
     endInsertRows();
 }
 
-void JobsModel::removeRows(const QList<int> &rows) {
+void JobsModel::removeJobRows(const QList<int> &rows) {
     QList<int> sorted = rows;
     std::sort(sorted.begin(), sorted.end(), std::greater<int>());
     for (int r : sorted) {

--- a/backy_x/src/core/Job.cpp
+++ b/backy_x/src/core/Job.cpp
@@ -1,0 +1,83 @@
+#include "core/Job.h"
+
+JobsModel::JobsModel(QObject *parent) : QAbstractTableModel(parent) {}
+
+int JobsModel::rowCount(const QModelIndex &) const { return jobs_.size(); }
+int JobsModel::columnCount(const QModelIndex &) const { return 4; }
+
+QVariant JobsModel::data(const QModelIndex &index, int role) const {
+    if (!index.isValid() || index.row() >= jobs_.size())
+        return {};
+    const Job &j = jobs_[index.row()];
+    if (role == Qt::DisplayRole) {
+        switch (index.column()) {
+        case 0:
+            return j.type == JobType::Scheduled ? tr("Scheduled") : tr("Watch");
+        case 1: {
+            if (j.type == JobType::Scheduled) {
+                QStringList days;
+                for (int d = 0; d < 7; ++d)
+                    if (j.daysMask.testBit(d))
+                        days << QLocale().dayName(d + 1, QLocale::ShortFormat);
+                return j.time.toString("HH:mm") +
+                       (days.isEmpty() ? QString(" (All)")
+                                       : " (" + days.join(',') + ")");
+            }
+            return QString();
+        }
+        case 2:
+            return j.type == JobType::Watch ? j.interval : QVariant();
+        case 3:
+            return j.next.isValid() ? j.next.toString("yyyy-MM-dd HH:mm")
+                                    : QString();
+        }
+    }
+    return {};
+}
+
+QVariant JobsModel::headerData(int section, Qt::Orientation orient, int role) const {
+    if (orient == Qt::Horizontal && role == Qt::DisplayRole) {
+        switch (section) {
+        case 0:
+            return tr("Type");
+        case 1:
+            return tr("When");
+        case 2:
+            return tr("Interval");
+        case 3:
+            return tr("Next");
+        }
+    }
+    return QAbstractTableModel::headerData(section, orient, role);
+}
+
+Qt::ItemFlags JobsModel::flags(const QModelIndex &index) const {
+    if (!index.isValid())
+        return Qt::NoItemFlags;
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+}
+
+void JobsModel::addJob(const Job &job) {
+    beginInsertRows(QModelIndex(), jobs_.size(), jobs_.size());
+    jobs_.append(job);
+    endInsertRows();
+}
+
+void JobsModel::removeRows(const QList<int> &rows) {
+    QList<int> sorted = rows;
+    std::sort(sorted.begin(), sorted.end(), std::greater<int>());
+    for (int r : sorted) {
+        if (r < 0 || r >= jobs_.size())
+            continue;
+        beginRemoveRows(QModelIndex(), r, r);
+        jobs_.removeAt(r);
+        endRemoveRows();
+    }
+}
+
+void JobsModel::setJobNext(int row, const QDateTime &dt) {
+    if (row < 0 || row >= jobs_.size())
+        return;
+    jobs_[row].next = dt;
+    emit dataChanged(index(row, 3), index(row, 3));
+}

--- a/backy_x/src/core/Scheduler.cpp
+++ b/backy_x/src/core/Scheduler.cpp
@@ -378,6 +378,37 @@ QString Scheduler::gcsAccountIdentifier() const {
                             // identifier
 }
 
+void Scheduler::computeNextRuns(JobsModel *model) const {
+  if (!model)
+    return;
+  QDateTime now = QDateTime::currentDateTime();
+  for (int r = 0; r < model->rowCount(); ++r) {
+    Job &j = model->jobRef(r);
+    if (j.type != JobType::Scheduled || !j.enabled) {
+      model->setJobNext(r, QDateTime());
+      continue;
+    }
+    QDateTime best;
+    bool found = false;
+    for (int offset = 0; offset < 7; ++offset) {
+      QDate date = now.date().addDays(offset);
+      int idx = date.dayOfWeek() - 1;
+      if (j.daysMask.size() == 7 && !j.daysMask.testBit(idx))
+        continue;
+      QDateTime cand(date, j.time);
+      if (cand <= now)
+        continue;
+      if (!found || cand < best) {
+        best = cand;
+        found = true;
+      }
+      if (found)
+        break;
+    }
+    model->setJobNext(r, found ? best : QDateTime());
+  }
+}
+
 // Example of how triggerBackupNow could be implemented if needed:
 // void Scheduler::triggerBackupNow() {
 //     if (taskEnabled_ && !currentSourcePath_.isEmpty() &&

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -7,6 +7,7 @@
 #include "gui/FileViewerWidget.h"
 #include "gui/WatchManager.h"
 #include "ui_MainWindow.h"
+#include "core/Job.h"
 
 #include <QApplication>
 #include <QGuiApplication>
@@ -145,10 +146,13 @@ void MainWindow::setupUI() {
   destinationDirEdit_ = ui->destinationDirEdit;
   destinationDirButton_ = ui->destinationDirButton;
   backupTimeEdit_ = ui->backupTimeEdit;
-  addTimeButton_ = ui->addTimeButton;
+  addTimeButton_ = ui->btnAddSched;
   timeListWidget_ = ui->timeListWidget;
-  removeTimeButton_ = ui->removeTimeButton;
-  runBackupButton_ = ui->runBackupButton;
+  removeTimeButton_ = ui->btnRemoveSelected;
+  runBackupButton_ = ui->btnRunNow;
+  tvJobs_ = ui->tvJobs;
+  btnRunNow_ = ui->btnRunNow;
+  btnRemoveSelected_ = ui->btnRemoveSelected;
   scheduleSummaryLabel_ = ui->scheduleSummaryLabel;
   logDisplay_ = ui->logDisplay;
   backupProgressBar_ = ui->backupProgressBar;
@@ -176,6 +180,17 @@ void MainWindow::setupUI() {
   fileViewerDockWidget_ = ui->fileViewerDockWidget;
   backupModeComboBox_ = ui->backupModeComboBox;
   backupModeStackedWidget_ = ui->backupModeStackedWidget;
+  jobsModel_ = new JobsModel(this);
+  if (tvJobs_) {
+    tvJobs_->setModel(jobsModel_);
+    tvJobs_->setSelectionBehavior(QAbstractItemView::SelectRows);
+  }
+  if (ui->wdPlan)
+    ui->wdPlan->setMinimumWidth(320);
+  if (ui->wdWatch)
+    ui->wdWatch->setMinimumWidth(320);
+  if (ui->splitPlanVsWatch)
+    ui->splitPlanVsWatch->setSizes({1, 1});
 
   // Collect day buttons
   dayButtons_.clear();
@@ -213,7 +228,7 @@ void MainWindow::setupUI() {
   connect(addTimeButton_, &QToolButton::clicked, this,
           &MainWindow::onAddBackupTimeClicked);
   connect(removeTimeButton_, &QPushButton::clicked, this,
-          &MainWindow::onRemoveBackupTimeClicked);
+          &MainWindow::onRemoveSelectedJob);
   connect(runBackupButton_, &QPushButton::clicked, this, &MainWindow::runBackupNow);
   connect(ui->actionRunBackup, &QAction::triggered, this, &MainWindow::runBackupNow);
   connect(cbWatch_, &QCheckBox::toggled, this, &MainWindow::onWatchToggled);
@@ -306,7 +321,16 @@ void MainWindow::onAddBackupTimeClicked() {
   timeListWidget_->addItem(item);
   for (QAbstractButton *btn : dayButtons_)
     btn->setChecked(false);
-  updateScheduleFromUI();
+  Job j;
+  j.type = JobType::Scheduled;
+  j.time = t;
+  QBitArray mask(7);
+  for (int i = 0; i < dayNums.size(); ++i)
+    mask.setBit(dayNums[i].toInt() - 1, true);
+  j.daysMask = mask;
+  jobsModel_->addJob(j);
+  scheduler_->computeNextRuns(jobsModel_);
+  updateScheduleSummary();
 }
 
 void MainWindow::onRemoveBackupTimeClicked() {
@@ -322,6 +346,18 @@ void MainWindow::onRemoveBackupTimeClicked() {
   lblWatchStatus_->setText("");
   updateWatchStatusIcon();
   updateScheduleFromUI();
+}
+
+void MainWindow::onRemoveSelectedJob() {
+  if (!tvJobs_)
+    return;
+  QModelIndexList rows = tvJobs_->selectionModel()->selectedRows();
+  QList<int> toRemove;
+  for (const QModelIndex &idx : rows)
+    toRemove << idx.row();
+  jobsModel_->removeRows(toRemove);
+  scheduler_->computeNextRuns(jobsModel_);
+  updateScheduleSummary();
 }
 
 void MainWindow::onAddWatchEntry() {
@@ -434,6 +470,10 @@ void MainWindow::onWatchToggled(bool checked) {
     refreshWatchEntriesDisplay();
     if (watchManager_->entries().isEmpty())
       onAddWatchEntry();
+    Job j;
+    j.type = JobType::Watch;
+    j.interval = sbWatchInterval_->value();
+    jobsModel_->addJob(j);
   } else {
     watchManager_->disable();
     for (int i = timeListWidget_->count() - 1; i >= 0; --i) {
@@ -445,10 +485,16 @@ void MainWindow::onWatchToggled(bool checked) {
     lblWatchStatus_->setText("");
     updateWatchStatusIcon();
     updateScheduleSummary();
+    QList<int> rows;
+    for (int r = 0; r < jobsModel_->rowCount(); ++r)
+      if (jobsModel_->jobRef(r).type == JobType::Watch)
+        rows << r;
+    jobsModel_->removeRows(rows);
   }
   sbWatchInterval_->setEnabled(checked);
   if (checked)
     watchManager_->setInterval(sbWatchInterval_->value());
+  scheduler_->computeNextRuns(jobsModel_);
 }
 
 
@@ -1644,24 +1690,21 @@ void MainWindow::applyUnifiedStyle(QWidget *widget) {
 
 
 void MainWindow::updateScheduleSummary() {
-  if (!scheduleSummaryLabel_ || !timeListWidget_)
+  if (!scheduleSummaryLabel_ || !jobsModel_)
     return;
   int count = 0;
-  QTime earliest;
-  bool first = true;
-  for (int i = 0; i < timeListWidget_->count(); ++i) {
-    QString data = timeListWidget_->item(i)->data(Qt::UserRole).toString();
-    if (data.startsWith("WATCH|"))
+  QDateTime earliest;
+  for (int r = 0; r < jobsModel_->rowCount(); ++r) {
+    const Job &j = jobsModel_->jobRef(r);
+    if (j.type != JobType::Scheduled)
       continue;
-    QString timeStr = data.split('|').value(0);
-    QTime t = QTime::fromString(timeStr, "HH:mm");
-    if (t.isValid() && (first || t < earliest)) {
-      earliest = t;
-      first = false;
-    }
     ++count;
+    if (j.next.isValid() && (!earliest.isValid() || j.next < earliest))
+      earliest = j.next;
   }
-  QString nextText = earliest.isValid() ? earliest.toString("HH:mm") : "--:--";
+  QString nextText = earliest.isValid()
+                           ? earliest.toString("yyyy-MM-dd HH:mm")
+                           : "--";
   scheduleSummaryLabel_->setText(
       QString::fromUtf8("\xF0\x9F\x93\x85 %1 scheduled backup%2 | \xF0\x9F\x95\x92 Next: %3")
           .arg(count)

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -355,7 +355,7 @@ void MainWindow::onRemoveSelectedJob() {
   QList<int> toRemove;
   for (const QModelIndex &idx : rows)
     toRemove << idx.row();
-  jobsModel_->removeRows(toRemove);
+  jobsModel_->removeJobRows(toRemove);
   scheduler_->computeNextRuns(jobsModel_);
   updateScheduleSummary();
 }
@@ -489,7 +489,7 @@ void MainWindow::onWatchToggled(bool checked) {
     for (int r = 0; r < jobsModel_->rowCount(); ++r)
       if (jobsModel_->jobRef(r).type == JobType::Watch)
         rows << r;
-    jobsModel_->removeRows(rows);
+    jobsModel_->removeJobRows(rows);
   }
   sbWatchInterval_->setEnabled(checked);
   if (checked)

--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -202,7 +202,7 @@ void MainWindow::setupUI() {
   applyUnifiedStyle(ui->localDestinationGroupBox);
   applyUnifiedStyle(ui->sftpSettingsGroupBox);
   applyUnifiedStyle(ui->gcsSettingsGroupBox);
-  applyUnifiedStyle(ui->gbSchedule);
+  applyUnifiedStyle(ui->gbPlan);
 
   setMinimumSize(800, 600);
   if (QScreen *scr = QApplication::primaryScreen()) {

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -26,6 +26,7 @@
 
 // Forward declaration for Scheduler
 class Scheduler;
+#include "core/Job.h"
 #include "core/IStorageTarget.h"    // For FileMetadata
 #include "util/CredentialManager.h" // For CredentialManager
 #include "gui/WatchManager.h"
@@ -69,6 +70,7 @@ private slots:
   // Slots for File Viewer handled by FileViewerWidget
   void onAddBackupTimeClicked();
   void onRemoveBackupTimeClicked();
+  void onRemoveSelectedJob();
 
   // Auto watch slots
   void onAddWatchEntry();
@@ -95,6 +97,10 @@ private:
   QListWidget *timeListWidget_;
   QPushButton *removeTimeButton_;
   QPushButton *runBackupButton_;
+  QTableView *tvJobs_ = nullptr;
+  QPushButton *btnRunNow_ = nullptr;
+  QPushButton *btnRemoveSelected_ = nullptr;
+  JobsModel *jobsModel_ = nullptr;
   QLabel *scheduleSummaryLabel_{nullptr};
   QTextEdit *logDisplay_;
 

--- a/backy_x/src/gui/MainWindow.h
+++ b/backy_x/src/gui/MainWindow.h
@@ -2,6 +2,7 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QObject>
 #include <QString>
 
 // Qt class includes
@@ -19,6 +20,7 @@
 #include <QListWidget>
 #include <QSpinBox>
 #include <QPushButton>
+#include <QTableView>
 #include <QVBoxLayout>
 #include <QTextEdit>
 #include <QTimeEdit>

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -573,6 +573,8 @@
           </item>
           </layout>
          </widget>
+        </item>
+        </layout>
         </widget>
         <widget class="QWidget" name="wdWatch">
          <layout class="QVBoxLayout" name="vlWatch">

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -341,13 +341,19 @@
       </widget>
      </widget>
     </item>
-        <!-- Schedule group -->
         <item>
-         <widget class="QGroupBox" name="gbSchedule">
-          <property name="title">
-           <string>Backup Schedule</string>
+         <widget class="QSplitter" name="splitPlanVsWatch">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <layout class="QGridLayout" name="scheduleLayout">
+          <widget class="QWidget" name="wdPlan">
+           <layout class="QVBoxLayout" name="vlPlan">
+            <item>
+             <widget class="QGroupBox" name="gbPlan">
+              <property name="title">
+               <string>Backup Schedule</string>
+              </property>
+              <layout class="QGridLayout" name="scheduleLayout">
            <!-- Row 0: day buttons, time and add -->
            <item row="0" column="0" colspan="3">
             <layout class="QHBoxLayout" name="scheduleRow">
@@ -513,7 +519,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QToolButton" name="addTimeButton">
+              <widget class="QToolButton" name="btnAddSched">
                <property name="text">
                 <string>+</string>
                </property>
@@ -552,34 +558,6 @@
              </layout>
             </widget>
            </item>
-           <item row="5" column="0" colspan="3">
-            <layout class="QHBoxLayout" name="buttonsLayout">
-             <item>
-              <widget class="QPushButton" name="removeTimeButton">
-               <property name="text">
-                <string>Remove Selected</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="buttonsSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Expanding</enum>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QPushButton" name="runBackupButton">
-               <property name="text">
-                <string>Run Backup Now</string>
-               </property>
-              </widget>
-             </item>
-           </layout>
-          </item>
           <item row="6" column="0" colspan="3">
            <widget class="QProgressBar" name="backupProgressBar">
             <property name="visible">
@@ -595,9 +573,11 @@
           </item>
           </layout>
          </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="gbWatch">
+        </widget>
+        <widget class="QWidget" name="wdWatch">
+         <layout class="QVBoxLayout" name="vlWatch">
+          <item>
+           <widget class="QGroupBox" name="gbWatch">
           <property name="title">
            <string>Real-Time Folder Watch</string>
           </property>
@@ -667,9 +647,48 @@
             </widget>
            </item>
           </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+      <item>
+       <widget class="QTableView" name="tvJobs">
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="bottomButtons">
+        <item>
+         <spacer name="bottomSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btnRunNow">
+          <property name="text">
+           <string>Run Now</string>
+          </property>
          </widget>
         </item>
-        <!-- Log toggle and display -->
+        <item>
+         <widget class="QPushButton" name="btnRemoveSelected">
+          <property name="text">
+           <string>Remove Selected</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <!-- Log toggle and display -->
         <item>
          <layout class="QVBoxLayout" name="logLayout">
           <item>

--- a/backy_x/src/targets/SftpTarget.cpp
+++ b/backy_x/src/targets/SftpTarget.cpp
@@ -188,14 +188,6 @@ curl_easy_setopt(m_curlHandle, CURLOPT_VERBOSE,   0L);            // déjà fait
         return true;
     };
 
-    // Helper lambda for setting non-critical options.
-    // On failure, it logs a warning. lastError_ is not set here to avoid overwriting a critical error.
-    auto setopt_non_critical = [&](CURLoption opt, auto val, const char* opt_name) {
-        res_setopt = curl_easy_setopt(m_curlHandle, opt, val);
-        if (res_setopt != CURLE_OK) {
-            std::cerr << "SftpTarget::setupCurlHandleForOperation: WARNING - Failed to set non-critical SFTP option " + std::string(opt_name) + ": " << curl_easy_strerror(res_setopt) << std::endl;
-        }
-    };
 
     // Set critical options
     if (!setopt_critical(CURLOPT_USERNAME, m_username.c_str(), "CURLOPT_USERNAME")) return false;
@@ -220,8 +212,7 @@ curl_easy_setopt(m_curlHandle, CURLOPT_VERBOSE,   0L);            // déjà fait
         if (!setopt_critical(CURLOPT_KEYPASSWD, m_sshKeyPassphrase.c_str(), "CURLOPT_KEYPASSWD")) return false;
     }
 
-    // Set non-critical options
-    // setopt_non_critical(CURLOPT_VERBOSE, m_verboseLogging ? 1L : 0L, "CURLOPT_VERBOSE"); // This line is intentionally removed/commented.
+    // Set non-critical options (none currently)
 
     // Enable CURLOPT_VERBOSE so that the CURLOPT_DEBUGFUNCTION is called.
     // The noop_debug_callback will then discard the actual verbose output.


### PR DESCRIPTION
## Summary
- create `Job` and `JobsModel`
- use JobsModel in MainWindow
- add splitter and job table to schedule page
- adjust scheduler to compute next run times

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c174f6fc8321b9f7cbb06f084b09