### PR TITLE
Compact LocalDestination group-box

### DIFF
--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -146,10 +146,10 @@
           <widget class="QWidget" name="LocalBackupPage">
            <layout class="QVBoxLayout" name="localBackupLayout">
            <property name="stretch">
-            <list>
-             <number>0</number>
-             <number>1</number>
-            </list>
+            <stringlist>
+             <string>0</string>
+             <string>1</string>
+            </stringlist>
            </property>
             <item>
              <widget class="QGroupBox" name="localDestinationGroupBox">
@@ -223,10 +223,10 @@
         <widget class="QWidget" name="SFTPBackupPage">
          <layout class="QVBoxLayout" name="sftpBackupLayout">
          <property name="stretch">
-          <list>
-           <number>0</number>
-           <number>1</number>
-          </list>
+          <stringlist>
+           <string>0</string>
+           <string>1</string>
+          </stringlist>
          </property>
           <item>
            <widget class="QGroupBox" name="sftpSettingsGroupBox">
@@ -337,10 +337,10 @@
        <widget class="QWidget" name="GCSBackupPage">
         <layout class="QVBoxLayout" name="gcsBackupLayout">
          <property name="stretch">
-          <list>
-           <number>0</number>
-           <number>1</number>
-          </list>
+          <stringlist>
+           <string>0</string>
+           <string>1</string>
+          </stringlist>
          </property>
          <item>
           <widget class="QGroupBox" name="gcsSettingsGroupBox">

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -145,12 +145,6 @@
          <widget class="QStackedWidget" name="backupModeStackedWidget">
           <widget class="QWidget" name="LocalBackupPage">
            <layout class="QVBoxLayout" name="localBackupLayout">
-           <property name="stretch">
-            <stringlist>
-             <string>0</string>
-             <string>1</string>
-            </stringlist>
-           </property>
             <item>
              <widget class="QGroupBox" name="localDestinationGroupBox">
               <property name="sizePolicy">
@@ -158,9 +152,6 @@
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
-              </property>
-              <property name="sizeAdjustPolicy">
-               <enum>QWidget::AdjustToContents</enum>
               </property>
               <property name="maximumHeight">
                <number>120</number>
@@ -222,12 +213,6 @@
         <!-- SFTP group -->
         <widget class="QWidget" name="SFTPBackupPage">
          <layout class="QVBoxLayout" name="sftpBackupLayout">
-         <property name="stretch">
-          <stringlist>
-           <string>0</string>
-           <string>1</string>
-          </stringlist>
-         </property>
           <item>
            <widget class="QGroupBox" name="sftpSettingsGroupBox">
             <property name="sizePolicy">
@@ -235,9 +220,6 @@
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QWidget::AdjustToContents</enum>
             </property>
             <property name="maximumHeight">
              <number>120</number>
@@ -336,12 +318,6 @@
        <!-- GCS group -->
        <widget class="QWidget" name="GCSBackupPage">
         <layout class="QVBoxLayout" name="gcsBackupLayout">
-         <property name="stretch">
-          <stringlist>
-           <string>0</string>
-           <string>1</string>
-          </stringlist>
-         </property>
          <item>
           <widget class="QGroupBox" name="gcsSettingsGroupBox">
           <property name="sizePolicy">
@@ -349,9 +325,6 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
-          </property>
-          <property name="sizeAdjustPolicy">
-           <enum>QWidget::AdjustToContents</enum>
           </property>
           <property name="maximumHeight">
            <number>120</number>

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -144,7 +144,7 @@
         <item>
          <widget class="QStackedWidget" name="backupModeStackedWidget">
           <widget class="QWidget" name="LocalBackupPage">
-          <layout class="QVBoxLayout" name="localBackupLayout">
+           <layout class="QVBoxLayout" name="localBackupLayout">
            <property name="stretch">
             <list>
              <number>0</number>
@@ -152,7 +152,7 @@
             </list>
            </property>
             <item>
-            <widget class="QGroupBox" name="localDestinationGroupBox">
+             <widget class="QGroupBox" name="localDestinationGroupBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -204,9 +204,9 @@
              </property>
             </widget>
            </item>
-           </layout>
-            </widget>
-           </item>
+          </layout>
+           </widget>
+          </item>
            <item>
             <spacer name="localSpacer">
              <property name="orientation">
@@ -217,17 +217,17 @@
              </property>
             </spacer>
            </item>
-          </layout>
+         </layout>
         </widget>
         <!-- SFTP group -->
         <widget class="QWidget" name="SFTPBackupPage">
          <layout class="QVBoxLayout" name="sftpBackupLayout">
-          <property name="stretch">
-           <list>
-            <number>0</number>
-            <number>1</number>
-           </list>
-          </property>
+         <property name="stretch">
+          <list>
+           <number>0</number>
+           <number>1</number>
+          </list>
+         </property>
           <item>
            <widget class="QGroupBox" name="sftpSettingsGroupBox">
             <property name="sizePolicy">
@@ -318,18 +318,18 @@
              </property>
             </widget>
            </item>
-           <item>
-            <spacer name="sftpSpacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Expanding</enum>
-             </property>
-            </spacer>
-           </item>
            </layout>
           </widget>
+         </item>
+         <item>
+          <spacer name="sftpSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+          </spacer>
          </item>
         </layout>
        </widget>
@@ -408,23 +408,33 @@
              </property>
             </widget>
            </item>
-           <item>
-            <spacer name="gcsSpacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Expanding</enum>
-             </property>
-            </spacer>
-           </item>
           </layout>
          </widget>
         </item>
+       <item>
+        <spacer name="gcsSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+        </spacer>
+       </item>
        </layout>
       </widget>
      </widget>
     </item>
+       <item>
+        <spacer name="destEndSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+        </spacer>
+       </item>
         <item>
          <widget class="QSplitter" name="splitPlanVsWatch">
           <property name="orientation">
@@ -804,16 +814,6 @@
            </widget>
           </item>
          </layout>
-        </item>
-        <item>
-         <spacer name="destEndSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-         </spacer>
         </item>
        </layout>
       </widget>

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -144,9 +144,27 @@
         <item>
          <widget class="QStackedWidget" name="backupModeStackedWidget">
           <widget class="QWidget" name="LocalBackupPage">
-           <layout class="QVBoxLayout" name="localBackupLayout">
+          <layout class="QVBoxLayout" name="localBackupLayout">
+           <property name="stretch">
+            <list>
+             <number>0</number>
+             <number>1</number>
+            </list>
+           </property>
             <item>
-             <widget class="QGroupBox" name="localDestinationGroupBox">
+            <widget class="QGroupBox" name="localDestinationGroupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="sizeAdjustPolicy">
+               <enum>QWidget::AdjustToContents</enum>
+              </property>
+              <property name="maximumHeight">
+               <number>120</number>
+              </property>
               <property name="title">
                <string>Local Destination Configuration</string>
               </property>
@@ -186,16 +204,44 @@
              </property>
             </widget>
            </item>
+           </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="localSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Expanding</enum>
+             </property>
+            </spacer>
+           </item>
           </layout>
-           </widget>
-          </item>
-         </layout>
         </widget>
         <!-- SFTP group -->
         <widget class="QWidget" name="SFTPBackupPage">
          <layout class="QVBoxLayout" name="sftpBackupLayout">
+          <property name="stretch">
+           <list>
+            <number>0</number>
+            <number>1</number>
+           </list>
+          </property>
           <item>
            <widget class="QGroupBox" name="sftpSettingsGroupBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QWidget::AdjustToContents</enum>
+            </property>
+            <property name="maximumHeight">
+             <number>120</number>
+            </property>
             <property name="title">
              <string>SFTP Configuration</string>
             </property>
@@ -272,6 +318,16 @@
              </property>
             </widget>
            </item>
+           <item>
+            <spacer name="sftpSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Expanding</enum>
+             </property>
+            </spacer>
+           </item>
            </layout>
           </widget>
          </item>
@@ -280,8 +336,26 @@
        <!-- GCS group -->
        <widget class="QWidget" name="GCSBackupPage">
         <layout class="QVBoxLayout" name="gcsBackupLayout">
+         <property name="stretch">
+          <list>
+           <number>0</number>
+           <number>1</number>
+          </list>
+         </property>
          <item>
           <widget class="QGroupBox" name="gcsSettingsGroupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QWidget::AdjustToContents</enum>
+          </property>
+          <property name="maximumHeight">
+           <number>120</number>
+          </property>
           <property name="title">
            <string>Google Cloud Storage Configuration</string>
           </property>
@@ -333,6 +407,16 @@
               <string>Connect</string>
              </property>
             </widget>
+           </item>
+           <item>
+            <spacer name="gcsSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Expanding</enum>
+             </property>
+            </spacer>
            </item>
           </layout>
          </widget>
@@ -720,6 +804,16 @@
            </widget>
           </item>
          </layout>
+        </item>
+        <item>
+         <spacer name="destEndSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
+          </property>
+         </spacer>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
## Summary
- tighten layout for Local Destination Configuration and others
- add stretch/spacers so groupboxes don't fill scroll area

## Testing
- `xmllint --noout src/gui/MainWindow.ui`
- `ctest --output-on-failure` *(fails: include could not find requested file)*

------
https://chatgpt.com/codex/tasks/task_e_684493362e448321bf983b80d5641bdf