### PR TITLE
fix-splitter-unused-var

### DIFF
--- a/backy_x/src/gui/MainWindow.cpp
+++ b/backy_x/src/gui/MainWindow.cpp
@@ -1210,7 +1210,6 @@ void MainWindow::onBackupModeChanged(int index) {
   if (backupModeStackedWidget_)
     backupModeStackedWidget_->setCurrentIndex(index);
   QString currentModeText = backupModeComboBox_->itemText(index);
-  bool localSelected = (currentModeText == tr("Local Backup"));
   bool sftpSelected = (currentModeText == tr("SFTP Backup"));
   bool gcsSelected = (currentModeText == tr("Google Cloud Storage"));
 

--- a/backy_x/src/gui/MainWindow.ui
+++ b/backy_x/src/gui/MainWindow.ui
@@ -467,12 +467,13 @@
          </property>
         </spacer>
        </item>
-        <item>
-         <widget class="QWidget" name="splitPlanVsWatch">
-          <layout class="QHBoxLayout" name="planWatchLayout">
-           <item>
-            <widget class="QWidget" name="wdPlan">
-           <layout class="QVBoxLayout" name="vlPlan">
+       <item>
+        <widget class="QSplitter" name="splitPlanVsWatch">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <widget class="QWidget" name="wdPlan">
+          <layout class="QVBoxLayout" name="vlPlan">
             <item>
              <widget class="QGroupBox" name="gbPlan">
               <property name="title">
@@ -683,11 +684,9 @@
           </layout>
          </widget>
         </item>
-        </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="wdWatch">
+       </layout>
+       </widget>
+       <widget class="QWidget" name="wdWatch">
          <layout class="QVBoxLayout" name="vlWatch">
           <item>
            <widget class="QGroupBox" name="gbWatch">
@@ -764,9 +763,7 @@
           </item>
          </layout>
         </widget>
-       </item>
-      </layout>
-     </widget>
+      </widget>
     </item>
       <item>
        <widget class="QTableView" name="tvJobs">


### PR DESCRIPTION
## Summary
- make splitPlanVsWatch a horizontal QSplitter in MainWindow.ui
- drop unused `localSelected` variable

## Testing
- `xmllint --noout backy_x/src/gui/MainWindow.ui`
- `ctest --output-on-failure` *(fails: include could not find requested file)*

------
https://chatgpt.com/codex/tasks/task_e_68455884c8dc83219a62de568062cc28