### PR TITLE
Add refresh token storage for GCS auth

### DIFF
--- a/backy_x/src/cloud/gcs/GcsAuth.cpp
+++ b/backy_x/src/cloud/gcs/GcsAuth.cpp
@@ -6,6 +6,7 @@
 #include <QUrl>
 #include <QStandardPaths>
 #include <QDebug>
+#include <QSettings>
 #include <optional>
 #include <QtNetworkAuth/qoauthhttpserverreplyhandler.h>
 
@@ -51,14 +52,46 @@ GcsAuth::GcsAuth(QObject* parent)
     oauth_.setRequestedScopeTokens({
         "https://www.googleapis.com/auth/devstorage.read_write"});
 
+    credentialManager_ = std::unique_ptr<CredentialManager>(createPlatformCredentialManager());
+
+    QSettings settings;
+    settings.beginGroup("GCS");
+    accountIdentifier_ = settings.value("gcs_account_identifier", "default").toString();
+    settings.endGroup();
+
+    if (credentialManager_) {
+        auto tokenOpt = credentialManager_->retrieveGcsRefreshToken(accountIdentifier_);
+        if (tokenOpt && !tokenOpt->isEmpty()) {
+            oauth_.setRefreshToken(*tokenOpt);
+        }
+    }
+
     auto *handler = new QOAuthHttpServerReplyHandler(0, this);
     oauth_.setReplyHandler(handler);
+
+    // Extra params for Google
+    oauth_.setModifyParametersFunction([](QAbstractOAuth::Stage stage,
+                                          QVariantMap *params) {
+        if (stage == QAbstractOAuth::Stage::RequestingAuthorization) {
+            params->insert("access_type", "offline");
+            params->insert("prompt", "consent");
+        }
+    });
 
     connect(&oauth_, &QOAuth2AuthorizationCodeFlow::authorizeWithBrowser,
             [](const QUrl &url) { QDesktopServices::openUrl(url); });
 
     connect(&oauth_, &QOAuth2AuthorizationCodeFlow::granted, this, [this]() {
         qInfo() << "GCS auth success, token:" << oauth_.token();
+        QString rt = oauth_.refreshToken();
+        if (credentialManager_ && !rt.isEmpty()) {
+            credentialManager_->storeGcsRefreshToken(accountIdentifier_, rt);
+        }
+
+        QSettings s;
+        s.beginGroup("GCS");
+        s.setValue("gcs_last_authenticated_account", accountIdentifier_);
+        s.endGroup();
     });
 }
 

--- a/backy_x/src/cloud/gcs/GcsAuth.cpp
+++ b/backy_x/src/cloud/gcs/GcsAuth.cpp
@@ -8,7 +8,7 @@
 #include <QDebug>
 #include <QSettings>
 #include <optional>
-#include <QMultiMap>
+#include <QVariant>
 #include <QtNetworkAuth/qoauthhttpserverreplyhandler.h>
 
 namespace {
@@ -72,11 +72,10 @@ GcsAuth::GcsAuth(QObject* parent)
 
     // Extra params for Google
     oauth_.setModifyParametersFunction(
-        [](QAbstractOAuth::Stage stage,
-           QMultiMap<QString, QVariant>* params) {
+        [](QAbstractOAuth::Stage stage, QVariantMap *params) {
             if (stage == QAbstractOAuth::Stage::RequestingAuthorization) {
-                params->insert("access_type", "offline");
-                params->insert("prompt", "consent");
+                params->insert("access_type",  "offline");
+                params->insert("prompt",       "consent");
             }
         });
 

--- a/backy_x/src/cloud/gcs/GcsAuth.cpp
+++ b/backy_x/src/cloud/gcs/GcsAuth.cpp
@@ -8,6 +8,7 @@
 #include <QDebug>
 #include <QSettings>
 #include <optional>
+#include <QMultiMap>
 #include <QtNetworkAuth/qoauthhttpserverreplyhandler.h>
 
 namespace {
@@ -70,13 +71,14 @@ GcsAuth::GcsAuth(QObject* parent)
     oauth_.setReplyHandler(handler);
 
     // Extra params for Google
-    oauth_.setModifyParametersFunction([](QAbstractOAuth::Stage stage,
-                                          QVariantMap *params) {
-        if (stage == QAbstractOAuth::Stage::RequestingAuthorization) {
-            params->insert("access_type", "offline");
-            params->insert("prompt", "consent");
-        }
-    });
+    oauth_.setModifyParametersFunction(
+        [](QAbstractOAuth::Stage stage,
+           QMultiMap<QString, QVariant>* params) {
+            if (stage == QAbstractOAuth::Stage::RequestingAuthorization) {
+                params->insert("access_type", "offline");
+                params->insert("prompt", "consent");
+            }
+        });
 
     connect(&oauth_, &QOAuth2AuthorizationCodeFlow::authorizeWithBrowser,
             [](const QUrl &url) { QDesktopServices::openUrl(url); });

--- a/backy_x/src/cloud/gcs/GcsAuth.h
+++ b/backy_x/src/cloud/gcs/GcsAuth.h
@@ -2,6 +2,7 @@
 
 #include <QtCore/QObject>
 #include <QtNetworkAuth/qoauth2authorizationcodeflow.h>
+#include "util/CredentialManager.h"
 
 class GcsAuth : public QObject {
     Q_OBJECT                               // <-- indispensable
@@ -13,4 +14,6 @@ public:
 
 private:
     QOAuth2AuthorizationCodeFlow oauth_;
+    std::unique_ptr<CredentialManager> credentialManager_;
+    QString accountIdentifier_;
 };


### PR DESCRIPTION
## Summary
- store the GCS refresh token in the platform keychain
- load stored refresh token at startup
- request offline consent for Google OAuth

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68472e9f8fb08321b1df297d8cc1935f